### PR TITLE
Rename: Rename Upload Text to Upload to Pastebin

### DIFF
--- a/src/pages/dashboard/upload/text.tsx
+++ b/src/pages/dashboard/upload/text.tsx
@@ -10,7 +10,7 @@ export default function UploadTextPage(props) {
 
   if (loading) return <LoadingOverlay visible={loading} />;
 
-  const title = `${props.title} - Upload Text`;
+  const title = `${props.title} - Upload to Pastebin`;
   return (
     <>
       <Head>


### PR DESCRIPTION
The term "Pastebin" is implied for organizing and better naming.