### PR TITLE
Prevent folders getting clipped off

### DIFF
--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -5,3 +5,10 @@
   font-weight: 700;
   font-size: var(--mantine-font-size-xl);
 }
+
+.mantine-Modal-content {
+  overflow-y: visible !important;
+}
+.mantine-Combobox-dropdown {
+  z-index: 999999 !important;
+}


### PR DESCRIPTION
At the moment, if you have a large number of folders, many of them get clipped off:
<img width="760" height="535" alt="image" src="https://github.com/user-attachments/assets/5511e910-dcd0-426b-8e76-c84c8ae0ee60" />
With these styles applied, they display correctly:
<img width="817" height="639" alt="image" src="https://github.com/user-attachments/assets/6d0c511a-8bfa-4a91-9510-7c02b76bf2ce" />
