### PR TITLE
Add public profiles, avatars, banners and markdown revamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "isomorphic-dompurify": "^3.12.0",
     "katex": "^0.16.46",
     "mantine-datatable": "^9.2.0",
+    "marked": "^18.0.5",
     "marked-react": "^4.0.0",
     "ms": "^2.1.3",
     "multer": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       mantine-datatable:
         specifier: ^9.2.0
         version: 9.2.0(@mantine/core@9.2.0(@mantine/hooks@9.2.0(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@9.2.0(react@19.2.6))(clsx@2.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
       marked-react:
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.6)
@@ -358,6 +361,7 @@ packages:
   '@aws-sdk/core@3.974.9':
     resolution: {integrity: sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.8':
     resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}
@@ -3392,6 +3396,11 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -4030,6 +4039,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8199,6 +8209,8 @@ snapshots:
       react: 19.2.6
 
   marked@17.0.6: {}
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -287,6 +287,10 @@ model File {
   favorite     Boolean @default(false)
   password     String?
   anonymous    Boolean @default(false)
+  public       Boolean @default(false)
+
+  width        Int?
+  height       Int?
 
   tags Tag[]
 

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,14 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="manifest" href="manifest.json">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="manifest.json" />
 
-		<title>Zipline</title>
-	</head>
-	<body>
-		<div id="root"></div>
-		<script type="module" src="/main.tsx"></script>
-	</body>
+    <title>Zipline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
 </html>

--- a/src/client/pages/user/[username].tsx
+++ b/src/client/pages/user/[username].tsx
@@ -1,0 +1,667 @@
+import { useParams, Link } from 'react-router-dom';
+import useSWR from 'swr';
+import {
+  Container,
+  Paper,
+  Title,
+  Text,
+  Avatar,
+  Group,
+  SimpleGrid,
+  Card,
+  Stack,
+  Center,
+  Loader,
+  Button,
+  Badge,
+  FileButton,
+  ActionIcon,
+  Modal,
+  TextInput,
+} from '@mantine/core';
+import {
+  IconCalendar,
+  IconEye,
+  IconFile,
+  IconArrowLeft,
+  IconFolders,
+  IconLayoutGrid,
+  IconLock,
+  IconWorld,
+  IconPhotoUp,
+  IconTrash,
+  IconPencil,
+  IconLink,
+} from '@tabler/icons-react';
+import { useTitle } from '@/lib/client/hooks/useTitle';
+import { bytes } from '@/lib/bytes';
+import RelativeDate from '@/components/RelativeDate';
+import { useUserStore } from '@/lib/client/store/user';
+import { readToDataURL } from '@/lib/base64';
+import { fetchApi } from '@/lib/fetchApi';
+import { notifications } from '@mantine/notifications';
+import { useState, useMemo, useEffect } from 'react';
+import DashboardFileModal from '@/components/file/DashboardFile/DashboardFileModal';
+import { useFileNavStore } from '@/lib/client/store/fileNav';
+import Markdown from '@/components/render/Markdown';
+
+const customStyles = `
+  .gallery-card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+  }
+  .gallery-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+    border-color: var(--mantine-color-blue-filled) !important;
+  }
+  .media-preview-container {
+    position: relative;
+    overflow: hidden;
+    background-color: #1e1f22;
+    aspect-ratio: 16 / 9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .media-preview-container img, .media-preview-container video {
+    transition: transform 0.3s ease;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .gallery-card:hover .media-preview-container img {
+    transform: scale(1.05);
+  }
+  /* Prevent browser link-preview tooltip on card clicks */
+  .gallery-card * {
+    pointer-events: none;
+  }
+  .profile-banner {
+    height: 140px;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    position: relative;
+  }
+  .banner-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0);
+    transition: background 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+  }
+  .banner-overlay:hover {
+    background: rgba(0,0,0,0.45);
+  }
+  .banner-overlay .banner-btns {
+    opacity: 0;
+    transition: opacity 0.2s;
+    display: flex;
+    gap: 8px;
+  }
+  .banner-overlay:hover .banner-btns {
+    opacity: 1;
+  }
+`;
+
+export function Component() {
+  const { username } = useParams<{ username: string }>();
+  useTitle(`${username}'s Profile`);
+
+  const currentUser = useUserStore((state) => state.user);
+
+  const { data, error, isLoading, mutate } = useSWR<{
+    user: {
+      username: string;
+      avatar: string | null;
+      banner: string | null;
+      bio: string | null;
+      createdAt: string;
+      stats?: {
+        totalViews: number | null;
+        totalUploads: number | null;
+        privateUploads: number | null;
+        publicUploads: number | null;
+      };
+    };
+    files: {
+      id: string;
+      name: string;
+      originalName: string | null;
+      type: string;
+      size: number;
+      views: number;
+      createdAt: string;
+      url: string;
+      thumbnail?: {
+        path: string;
+      } | null;
+    }[];
+  }>(username ? `/api/users/${username}/public` : null);
+
+  const [selectedFile, setSelectedFile] = useState<any | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  // Link upload / setting modals
+  const [linkModalOpen, setLinkModalOpen] = useState(false);
+  const [linkModalType, setLinkModalType] = useState<'avatar' | 'banner'>('avatar');
+  const [linkInput, setLinkInput] = useState('');
+  const [avatarEditModalOpen, setAvatarEditModalOpen] = useState(false);
+
+  const openLinkModal = (type: 'avatar' | 'banner') => {
+    setLinkModalType(type);
+    setLinkInput('');
+    setLinkModalOpen(true);
+  };
+
+  const handleLinkSave = async () => {
+    const url = linkInput.trim();
+    if (!url) return;
+
+    if (linkModalType === 'avatar') {
+      const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+        avatar: url,
+      });
+      if (resError) {
+        notifications.show({ title: 'Error updating avatar', message: resError.error, color: 'red' });
+      } else {
+        notifications.show({ message: 'Avatar updated successfully!', color: 'green' });
+        mutate();
+      }
+    } else {
+      const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+        view: { banner: url },
+      });
+      if (resError) {
+        notifications.show({ title: 'Error updating banner', message: resError.error, color: 'red' });
+      } else {
+        notifications.show({ message: 'Profile banner updated successfully!', color: 'green' });
+        mutate();
+      }
+    }
+
+    setLinkModalOpen(false);
+  };
+
+  const setFiles = useFileNavStore((state) => state.setFiles);
+  const setCurrent = useFileNavStore((state) => state.setCurrent);
+
+  const fileIds = useMemo(() => (data?.files ?? []).map((file) => file.id), [data?.files]);
+
+  useEffect(() => {
+    if (data?.files) {
+      setFiles(fileIds);
+    }
+  }, [fileIds, data?.files, setFiles]);
+
+  useEffect(() => {
+    const handleDragStart = (e: DragEvent) => {
+      const target = e.target as HTMLElement;
+      if (target && (target.tagName === 'IMG' || target.tagName === 'VIDEO')) {
+        e.preventDefault();
+      }
+    };
+
+    const handleLinkClick = (e: MouseEvent) => {
+      let target = e.target as HTMLElement | null;
+      while (target && target.tagName !== 'A') {
+        target = target.parentElement;
+      }
+      if (target && target.tagName === 'A') {
+        const href = target.getAttribute('href');
+        if (
+          href &&
+          (href.startsWith('http://') ||
+            href.startsWith('https://') ||
+            href.startsWith('/raw/') ||
+            href.startsWith('/view/') ||
+            href.startsWith('/u/'))
+        ) {
+          target.setAttribute('target', '_blank');
+          target.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+    };
+
+    document.addEventListener('dragstart', handleDragStart);
+    document.addEventListener('click', handleLinkClick);
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart);
+      document.removeEventListener('click', handleLinkClick);
+    };
+  }, []);
+
+  const handleCardClick = (file: any) => {
+    setSelectedFile(file);
+    setCurrent(file.id);
+    setPreviewOpen(true);
+  };
+
+  const currentFileId = useFileNavStore((state) => state.current);
+  const activeFile =
+    !currentFileId || !data?.files
+      ? selectedFile
+      : data.files.find((f) => f.id === currentFileId) || selectedFile;
+
+  const handleBannerUpload = async (file: File | null) => {
+    if (!file) return;
+    const base64url = await readToDataURL(file);
+    const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+      view: { banner: base64url },
+    });
+
+    if (resError) {
+      notifications.show({
+        title: 'Error updating banner',
+        message: resError.error,
+        color: 'red',
+      });
+    } else {
+      notifications.show({
+        message: 'Profile banner updated successfully!',
+        color: 'green',
+      });
+      mutate();
+    }
+  };
+
+  const handleBannerRemove = async () => {
+    const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+      view: { banner: null },
+    });
+
+    if (resError) {
+      notifications.show({
+        title: 'Error removing banner',
+        message: resError.error,
+        color: 'red',
+      });
+    } else {
+      notifications.show({
+        message: 'Profile banner removed successfully!',
+        color: 'green',
+      });
+      mutate();
+    }
+  };
+
+  const handleAvatarUpload = async (file: File | null) => {
+    if (!file) return;
+    const base64url = await readToDataURL(file);
+    const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+      avatar: base64url,
+    });
+
+    if (resError) {
+      notifications.show({
+        title: 'Error updating avatar',
+        message: resError.error,
+        color: 'red',
+      });
+    } else {
+      notifications.show({
+        message: 'Avatar updated successfully!',
+        color: 'green',
+      });
+      mutate();
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Center style={{ height: '100vh', flexDirection: 'column', gap: '12px' }}>
+        <Loader size='xl' />
+        <Text c='dimmed'>Loading public profile...</Text>
+      </Center>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Center style={{ height: '100vh', flexDirection: 'column', gap: '16px' }}>
+        <Title order={1}>404 - Profile Not Found</Title>
+        <Text c='dimmed'>The user profile you are looking for does not exist or has been removed.</Text>
+        <Button component={Link} to='/' leftSection={<IconArrowLeft size='1rem' />}>
+          Go Home
+        </Button>
+      </Center>
+    );
+  }
+
+  const { user, files } = data;
+  const isOwner = currentUser?.username === user.username;
+
+  return (
+    <Container size='lg' py='xl'>
+      <style dangerouslySetInnerHTML={{ __html: customStyles }} />
+
+      <DashboardFileModal
+        open={previewOpen}
+        setOpen={setPreviewOpen}
+        file={activeFile}
+        reduce={true}
+        sequenced
+      />
+
+      <Modal
+        opened={linkModalOpen}
+        onClose={() => setLinkModalOpen(false)}
+        title={`Set ${linkModalType === 'avatar' ? 'Avatar' : 'Banner'} URL`}
+        centered
+      >
+        <Stack gap='sm'>
+          <TextInput
+            label='Image URL'
+            placeholder={`https://example.com/${linkModalType}.gif`}
+            value={linkInput}
+            onChange={(e) => setLinkInput(e.currentTarget.value)}
+            required
+            autoFocus
+          />
+          <Group justify='flex-end' mt='md'>
+            <Button variant='subtle' onClick={() => setLinkModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleLinkSave} disabled={!linkInput.trim()}>
+              Save
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={avatarEditModalOpen}
+        onClose={() => setAvatarEditModalOpen(false)}
+        title='Update Avatar'
+        centered
+      >
+        <Stack gap='sm'>
+          <FileButton
+            onChange={(file) => {
+              setAvatarEditModalOpen(false);
+              handleAvatarUpload(file);
+            }}
+            accept='image/*'
+          >
+            {(props) => (
+              <Button {...props} fullWidth variant='light' leftSection={<IconPhotoUp size='1rem' />}>
+                Upload Image file
+              </Button>
+            )}
+          </FileButton>
+
+          <Button
+            fullWidth
+            variant='light'
+            leftSection={<IconLink size='1rem' />}
+            onClick={() => {
+              setAvatarEditModalOpen(false);
+              openLinkModal('avatar');
+            }}
+          >
+            Set Avatar from URL Link
+          </Button>
+
+          {user.avatar && (
+            <Button
+              fullWidth
+              variant='light'
+              color='red'
+              leftSection={<IconTrash size='1rem' />}
+              onClick={async () => {
+                setAvatarEditModalOpen(false);
+                const { error: resError } = await fetchApi('/api/user', 'PATCH', {
+                  avatar: null,
+                });
+                if (resError) {
+                  notifications.show({
+                    title: 'Error removing avatar',
+                    message: resError.error,
+                    color: 'red',
+                  });
+                } else {
+                  notifications.show({ message: 'Avatar removed successfully!', color: 'green' });
+                  mutate();
+                }
+              }}
+            >
+              Remove Avatar
+            </Button>
+          )}
+        </Stack>
+      </Modal>
+
+      {currentUser && currentUser.username !== user.username && (
+        <Group justify='flex-end' mb='lg'>
+          <Button component={Link} to={`/user/${currentUser.username}`} variant='outline'>
+            My Profile
+          </Button>
+        </Group>
+      )}
+
+      {/* User Header Profile Card */}
+      <Paper withBorder radius='md' mb='xl' style={{ overflow: 'hidden', position: 'relative' }}>
+        <div
+          className='profile-banner'
+          style={{
+            background: user.banner
+              ? `url(${user.banner}) no-repeat center/cover`
+              : 'linear-gradient(135deg, var(--mantine-color-blue-filled) 0%, var(--mantine-color-indigo-filled) 100%)',
+          }}
+        >
+          {isOwner && (
+            <div className='banner-overlay'>
+              <div className='banner-btns'>
+                <FileButton onChange={handleBannerUpload} accept='image/*'>
+                  {(props) => (
+                    <Button {...props} size='xs' variant='white' leftSection={<IconPhotoUp size='0.8rem' />}>
+                      Upload
+                    </Button>
+                  )}
+                </FileButton>
+                <Button
+                  size='xs'
+                  variant='white'
+                  leftSection={<IconLink size='0.8rem' />}
+                  onClick={() => openLinkModal('banner')}
+                >
+                  Link
+                </Button>
+                {user.banner && (
+                  <Button
+                    size='xs'
+                    variant='white'
+                    color='red'
+                    leftSection={<IconTrash size='0.8rem' />}
+                    onClick={handleBannerRemove}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+        <Container size='md' style={{ marginTop: '-50px', paddingBottom: '24px' }}>
+          <Stack align='center' gap='sm'>
+            <div style={{ position: 'relative' }}>
+              <Avatar
+                src={user.avatar || null}
+                size={100}
+                radius={100}
+                style={{ border: '4px solid var(--mantine-color-body)' }}
+              />
+              {isOwner && (
+                <ActionIcon
+                  size='md'
+                  radius='xl'
+                  variant='filled'
+                  color='blue'
+                  pos='absolute'
+                  bottom={0}
+                  right={0}
+                  style={{
+                    border: '2px solid var(--mantine-color-body)',
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+                  }}
+                  onClick={() => setAvatarEditModalOpen(true)}
+                >
+                  <IconPencil size='0.9rem' />
+                </ActionIcon>
+              )}
+            </div>
+            <Title order={1}>{user.username}</Title>
+
+            <Group gap='md' c='dimmed'>
+              <Group gap='xs'>
+                <IconCalendar size='1rem' />
+                <Text size='sm'>
+                  Joined <RelativeDate date={new Date(user.createdAt)} />
+                </Text>
+              </Group>
+              <Group gap='xs'>
+                <IconLayoutGrid size='1rem' />
+                <Text size='sm'>{files.length} public uploads</Text>
+              </Group>
+            </Group>
+
+            {user.bio && (
+              <div style={{ maxWidth: '600px', textAlign: 'center', wordBreak: 'break-word' }}>
+                <Markdown md={user.bio} plain />
+              </div>
+            )}
+
+            {/* Statistics Section */}
+            {user.stats && (
+              <Group gap='lg' justify='center' mt='xs' c='dimmed'>
+                {user.stats.totalViews !== null && (
+                  <Group gap='xs'>
+                    <IconEye size='1.1rem' style={{ color: 'var(--mantine-color-blue-filled)' }} />
+                    <Text size='sm' fw={500}>
+                      {user.stats.totalViews.toLocaleString()} views
+                    </Text>
+                  </Group>
+                )}
+                {user.stats.totalUploads !== null && (
+                  <Group gap='xs'>
+                    <IconFile size='1.1rem' style={{ color: 'var(--mantine-color-indigo-filled)' }} />
+                    <Text size='sm' fw={500}>
+                      {user.stats.totalUploads.toLocaleString()} uploads
+                    </Text>
+                  </Group>
+                )}
+                {user.stats.publicUploads !== null && (
+                  <Group gap='xs'>
+                    <IconWorld size='1.1rem' style={{ color: 'var(--mantine-color-green-filled)' }} />
+                    <Text size='sm' fw={500}>
+                      {user.stats.publicUploads.toLocaleString()} public
+                    </Text>
+                  </Group>
+                )}
+                {user.stats.privateUploads !== null && user.stats.privateUploads > 0 && (
+                  <Group gap='xs'>
+                    <IconLock size='1.1rem' style={{ color: 'var(--mantine-color-red-filled)' }} />
+                    <Text size='sm' fw={500}>
+                      {user.stats.privateUploads.toLocaleString()} private
+                    </Text>
+                  </Group>
+                )}
+              </Group>
+            )}
+          </Stack>
+        </Container>
+      </Paper>
+
+      {/* Public Gallery Section */}
+      <Stack gap='md'>
+        <Group align='center' gap='xs'>
+          <IconFolders size='1.5rem' />
+          <Title order={2}>/public/gallery</Title>
+        </Group>
+
+        {files.length === 0 ? (
+          <Paper withBorder p='xl' radius='md' style={{ textAlign: 'center' }}>
+            <Text size='lg' fw={500} mb='xs'>
+              No public files
+            </Text>
+            <Text c='dimmed'>This user hasn&apos;t made any files public yet.</Text>
+          </Paper>
+        ) : (
+          <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing='lg'>
+            {files.map((file) => {
+              const isImage = file.type.startsWith('image/');
+              const isVideo = file.type.startsWith('video/');
+              const thumbnailUrl = file.thumbnail ? `/raw/${file.thumbnail.path}` : null;
+              const rawUrl = `/raw/${file.name}`;
+              const displayUrl = thumbnailUrl || rawUrl;
+
+              return (
+                <Card
+                  key={file.id}
+                  withBorder
+                  padding='md'
+                  radius='md'
+                  className='gallery-card'
+                  onClick={() => handleCardClick(file)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <Card.Section className='media-preview-container'>
+                    {isImage ? (
+                      <img src={displayUrl} alt={file.originalName || file.name} loading='lazy' />
+                    ) : isVideo ? (
+                      thumbnailUrl ? (
+                        <img src={thumbnailUrl} alt={file.originalName || file.name} loading='lazy' />
+                      ) : (
+                        <video src={rawUrl} preload='metadata' muted />
+                      )
+                    ) : (
+                      <Center style={{ height: '100%', flexDirection: 'column', gap: '8px' }}>
+                        <IconFile size='3rem' style={{ color: 'var(--mantine-color-dimmed)' }} />
+                        <Text
+                          size='xs'
+                          c='dimmed'
+                          style={{ maxWidth: '80%', textAlign: 'center', wordBreak: 'break-all' }}
+                        >
+                          {file.type}
+                        </Text>
+                      </Center>
+                    )}
+                  </Card.Section>
+
+                  <Stack mt='md' gap='xs'>
+                    <Text fw={600} size='sm' truncate>
+                      {file.originalName || file.name}
+                    </Text>
+
+                    <Group justify='space-between' mt='xs'>
+                      <Badge variant='light' color='blue'>
+                        {bytes(file.size)}
+                      </Badge>
+                      <Group gap={4}>
+                        <IconEye size='0.9rem' style={{ color: 'var(--mantine-color-dimmed)' }} />
+                        <Text size='xs' c='dimmed'>
+                          {file.views} views
+                        </Text>
+                      </Group>
+                    </Group>
+
+                    <Text size='xs' c='dimmed'>
+                      Uploaded <RelativeDate date={new Date(file.createdAt)} />
+                    </Text>
+                  </Stack>
+                </Card>
+              );
+            })}
+          </SimpleGrid>
+        )}
+      </Stack>
+    </Container>
+  );
+}
+
+Component.displayName = 'UserProfile';

--- a/src/client/pages/view/[id].tsx
+++ b/src/client/pages/view/[id].tsx
@@ -19,12 +19,11 @@ import {
   PasswordInput,
   Text,
   Tooltip,
-  Typography,
 } from '@mantine/core';
 import { IconDownload, IconExternalLink, IconInfoCircleFilled } from '@tabler/icons-react';
-import * as sanitize from 'isomorphic-dompurify';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import Markdown from '@/components/render/Markdown';
 import { getFile } from '../../ssr-view/server';
 
 type SsrData = {
@@ -49,6 +48,43 @@ export default function ViewFileId() {
   const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
 
   useTitle(file.originalName ?? file.name ?? 'View File');
+
+  useEffect(() => {
+    const handleDragStart = (e: DragEvent) => {
+      const target = e.target as HTMLElement;
+      if (target && (target.tagName === 'IMG' || target.tagName === 'VIDEO')) {
+        e.preventDefault();
+      }
+    };
+
+    const handleLinkClick = (e: MouseEvent) => {
+      let target = e.target as HTMLElement | null;
+      while (target && target.tagName !== 'A') {
+        target = target.parentElement;
+      }
+      if (target && target.tagName === 'A') {
+        const href = target.getAttribute('href');
+        if (
+          href &&
+          (href.startsWith('http://') ||
+            href.startsWith('https://') ||
+            href.startsWith('/raw/') ||
+            href.startsWith('/view/') ||
+            href.startsWith('/u/'))
+        ) {
+          target.setAttribute('target', '_blank');
+          target.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+    };
+
+    document.addEventListener('dragstart', handleDragStart);
+    document.addEventListener('click', handleLinkClick);
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart);
+      document.removeEventListener('click', handleLinkClick);
+    };
+  }, []);
 
   return password && !token ? (
     <Modal onClose={() => {}} opened={true} withCloseButton={false} centered title='Password required'>
@@ -117,28 +153,22 @@ export default function ViewFileId() {
       <Collapse expanded={detailsOpen}>
         <Paper m='md' p='md' withBorder>
           {user?.view!.content && (
-            <Typography>
-              <Text
-                ta={user?.view!.align ?? 'left'}
-                dangerouslySetInnerHTML={{
-                  __html: sanitize.sanitize(
-                    parseString(user.view.content, {
-                      file: file as unknown as File,
-                      user: user as User,
-                      link: {
-                        returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
-                        raw: `${host}/raw/${file.name}`,
-                      },
-                      ...metrics,
-                    }) ?? '',
-                    {
-                      USE_PROFILES: { html: true },
-                      FORBID_TAGS: ['style', 'script'],
+            <div style={{ textAlign: user?.view!.align ?? 'left' }}>
+              <Markdown
+                plain
+                md={
+                  parseString(user.view.content, {
+                    file: file as unknown as File,
+                    user: user as User,
+                    link: {
+                      returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
+                      raw: `${host}/raw/${file.name}`,
                     },
-                  ),
-                }}
+                    ...metrics,
+                  }) ?? ''
+                }
               />
-            </Typography>
+            </div>
           )}
         </Paper>
       </Collapse>
@@ -218,29 +248,22 @@ export default function ViewFileId() {
           <DashboardFileType allowZoom file={file as unknown as File} token={token} show />
 
           {user?.view!.content && (
-            <Typography>
-              <Text
-                mt='sm'
-                ta={user?.view.align ?? 'left'}
-                dangerouslySetInnerHTML={{
-                  __html: sanitize.sanitize(
-                    parseString(user?.view.content, {
-                      file: file as unknown as File,
-                      link: {
-                        returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
-                        raw: `${host}/raw/${file.name}`,
-                      },
-                      user: user as User,
-                      ...metrics,
-                    }) ?? '',
-                    {
-                      USE_PROFILES: { html: true },
-                      FORBID_TAGS: ['script'],
+            <div style={{ marginTop: '0.5rem', textAlign: user?.view.align ?? 'left' }}>
+              <Markdown
+                plain
+                md={
+                  parseString(user?.view.content, {
+                    file: file as unknown as File,
+                    link: {
+                      returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
+                      raw: `${host}/raw/${file.name}`,
                     },
-                  ),
-                }}
+                    user: user as User,
+                    ...metrics,
+                  }) ?? ''
+                }
               />
-            </Typography>
+            </div>
           )}
         </Paper>
       </Center>

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -104,6 +104,14 @@ export const router = createBrowserRouter([
               },
             ],
           },
+          {
+            path: 'user/:username',
+            lazy: () => import('./pages/user/[username]'),
+          },
+          {
+            path: ':username',
+            lazy: () => import('./pages/user/[username]'),
+          },
         ],
       },
     ],

--- a/src/client/ssr-view/server.tsx
+++ b/src/client/ssr-view/server.tsx
@@ -173,42 +173,94 @@ export async function render(
   const showMediaOg = viewEnabled && (!!user.view.embed || !!user.view.embedMediaOnly);
   const pageUrl = `${host}${url.split('?')[0]}`;
 
-  const richMeta = [
+  const parsedTitle =
     showRichOg && user?.view?.embedTitle
-      ? `<meta property="og:title" content="${stripHtml(
+      ? stripHtml(
           parseString(user.view.embedTitle, {
             file: file as unknown as File,
             user: user as User,
             ...metrics,
           }) ?? '',
-        )}" />`
-      : '',
+        )
+      : '';
+
+  const parsedDescription =
     showRichOg && user?.view?.embedDescription
-      ? `<meta property="og:description" content="${stripHtml(
+      ? stripHtml(
           parseString(user.view.embedDescription, {
             file: file as unknown as File,
             user: user as User,
             ...metrics,
           }) ?? '',
-        )}" />`
-      : '',
+        )
+      : '';
+
+  const parsedSiteName =
     showRichOg && user?.view?.embedSiteName
-      ? `<meta property="og:site_name" content="${stripHtml(
+      ? stripHtml(
           parseString(user.view.embedSiteName, {
             file: file as unknown as File,
             user: user as User,
             ...metrics,
           }) ?? '',
-        )}" />`
-      : '',
+        )
+      : '';
+
+  const parsedColor =
     showRichOg && user?.view?.embedColor
-      ? `<meta property="theme-color" content="${stripHtml(
+      ? stripHtml(
           parseString(user.view.embedColor, {
             file: file as unknown as File,
             user: user as User,
             ...metrics,
           }) ?? '',
-        )}" />`
+        )
+      : '';
+
+  const parsedAuthor =
+    showRichOg && user?.view?.embedAuthor
+      ? stripHtml(
+          parseString(user.view.embedAuthor, {
+            file: file as unknown as File,
+            user: user as User,
+            ...metrics,
+          }) ?? '',
+        )
+      : user.username;
+
+  const parsedAuthorUrl =
+    showRichOg && user?.view?.embedAuthorUrl
+      ? stripHtml(
+          parseString(user.view.embedAuthorUrl, {
+            file: file as unknown as File,
+            user: user as User,
+            ...metrics,
+          }) ?? '',
+        )
+      : `${host}/user/${user.username}`;
+
+  const parsedProviderUrl =
+    showRichOg && user?.view?.embedProviderUrl
+      ? stripHtml(
+          parseString(user.view.embedProviderUrl, {
+            file: file as unknown as File,
+            user: user as User,
+            ...metrics,
+          }) ?? '',
+        )
+      : host;
+
+  const richMeta = [
+    parsedTitle ? `<meta property="og:title" content="${parsedTitle}" />` : '',
+    parsedDescription ? `<meta property="og:description" content="${parsedDescription}" />` : '',
+    parsedSiteName ? `<meta property="og:site_name" content="${parsedSiteName}" />` : '',
+    parsedColor ? `<meta property="theme-color" content="${parsedColor}" />` : '',
+    showRichOg
+      ? `<link rel="alternate" type="application/json+oembed" href="${host}/oembed?title=${encodeURIComponent(
+          parsedTitle || file.name,
+        )}&author=${encodeURIComponent(parsedAuthor)}&author_url=${encodeURIComponent(
+          parsedAuthorUrl,
+        )}${parsedSiteName ? `&provider=${encodeURIComponent(parsedSiteName)}` : ''}&provider_url=${encodeURIComponent(parsedProviderUrl)}" title="${stripHtml(file.name)}" />`
       : '',
   ]
     .filter(Boolean)
@@ -220,11 +272,18 @@ export async function render(
     <meta property="og:type" content="image" />
     <meta property="og:image" itemProp="image" content="${host}/raw/${safeFilename}" />
     <meta property="og:url" content="${pageUrl}" />
+    ${file.width ? `<meta property="og:image:width" content="${file.width}" />` : ''}
+    ${file.height ? `<meta property="og:image:height" content="${file.height}" />` : ''}
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:image" content="${host}/raw/${safeFilename}" />
+    ${file.width ? `<meta property="twitter:image:width" content="${file.width}" />` : ''}
+    ${file.height ? `<meta property="twitter:image:height" content="${file.height}" />` : ''}
     ${showRichOg ? `<meta property="twitter:title" content="${safeFilename}" />` : ''}
   `
       : '';
+
+  const videoWidth = file.width ?? 1920;
+  const videoHeight = file.height ?? 1080;
 
   const videoOg =
     showMediaOg && file.type?.startsWith('video')
@@ -232,9 +291,18 @@ export async function render(
     ${file.thumbnail ? `<meta property="og:image" content="${host}/raw/${file.thumbnail.path}" />` : ''}
     <meta property="og:type" content="video.other" />
     <meta property="og:url" content="${pageUrl}" />
+    <meta property="og:video" content="${host}/raw/${safeFilename}" />
     <meta property="og:video:url" content="${host}/raw/${safeFilename}" />
-    <meta property="og:video:width" content="1920" />
-    <meta property="og:video:height" content="1080" />
+    <meta property="og:video:secure_url" content="${host}/raw/${safeFilename}" />
+    <meta property="og:video:width" content="${videoWidth}" />
+    <meta property="og:video:height" content="${videoHeight}" />
+    <meta property="og:video:type" content="${safeType}" />
+    <meta property="twitter:card" content="player" />
+    <meta property="twitter:player" content="${host}/raw/${safeFilename}" />
+    <meta property="twitter:player:stream" content="${host}/raw/${safeFilename}" />
+    <meta property="twitter:player:stream:content_type" content="${safeType}" />
+    <meta property="twitter:player:width" content="${videoWidth}" />
+    <meta property="twitter:player:height" content="${videoHeight}" />
   `
       : '';
 

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -13,3 +13,30 @@
 .mantine-datatable {
   border-radius: var(--mantine-radius-default);
 }
+
+body {
+  user-select: none;
+}
+
+input,
+textarea,
+[contenteditable='true'],
+.selectable-text,
+.selectable-text *,
+pre,
+code,
+pre *,
+code *,
+.mantine-CodeHighlight-code,
+.mantine-CodeHighlight-code * {
+  user-select: text !important;
+}
+
+img,
+video {
+  -webkit-user-drag: none !important;
+  -khtml-user-drag: none !important;
+  -moz-user-drag: none !important;
+  -o-user-drag: none !important;
+  user-drag: none !important;
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -44,9 +44,10 @@ import {
   IconStopwatch,
   IconTags,
   IconUpload,
+  IconUser,
   IconUsersGroup,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, NavigateFunction, Outlet, useLoaderData, useLocation, useNavigate } from 'react-router-dom';
 import { dashboardLoader } from '../client/routes';
 import ConfigProvider from './ConfigProvider';
@@ -234,6 +235,43 @@ export default function Layout() {
   const { user, mutate } = useLogin();
   const { avatar } = useAvatar();
 
+  useEffect(() => {
+    const handleDragStart = (e: DragEvent) => {
+      const target = e.target as HTMLElement;
+      if (target && (target.tagName === 'IMG' || target.tagName === 'VIDEO')) {
+        e.preventDefault();
+      }
+    };
+
+    const handleLinkClick = (e: MouseEvent) => {
+      let target = e.target as HTMLElement | null;
+      while (target && target.tagName !== 'A') {
+        target = target.parentElement;
+      }
+      if (target && target.tagName === 'A') {
+        const href = target.getAttribute('href');
+        if (
+          href &&
+          (href.startsWith('http://') ||
+            href.startsWith('https://') ||
+            href.startsWith('/raw/') ||
+            href.startsWith('/view/') ||
+            href.startsWith('/u/'))
+        ) {
+          target.setAttribute('target', '_blank');
+          target.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+    };
+
+    document.addEventListener('dragstart', handleDragStart);
+    document.addEventListener('click', handleLinkClick);
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart);
+      document.removeEventListener('click', handleLinkClick);
+    };
+  }, []);
+
   const [prev, setPrev] = useState(location.pathname);
   if (prev !== location.pathname) {
     setPrev(location.pathname);
@@ -366,6 +404,14 @@ export default function Layout() {
                   prefetch='intent'
                 >
                   Settings
+                </Menu.Item>
+
+                <Menu.Item
+                  leftSection={<IconUser size='1rem' />}
+                  component={Link}
+                  to={`/user/${user?.username}`}
+                >
+                  View Public Profile
                 </Menu.Item>
 
                 {user?.role === 'SUPERADMIN' && (

--- a/src/components/file/DashboardFile/EditFileDetailsModal.tsx
+++ b/src/components/file/DashboardFile/EditFileDetailsModal.tsx
@@ -1,7 +1,7 @@
 import { File } from '@/lib/db/models/file';
 import { fetchApi } from '@/lib/fetchApi';
 import useObjectState from '@/lib/client/hooks/useObjectState';
-import { Button, Divider, Modal, NumberInput, PasswordInput, Stack, TextInput } from '@mantine/core';
+import { Button, Divider, Modal, NumberInput, PasswordInput, Stack, Switch, TextInput } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { IconEye, IconKey, IconPencil, IconPencilOff, IconTrashFilled } from '@tabler/icons-react';
 import { useEffect } from 'react';
@@ -22,12 +22,14 @@ export default function EditFileDetailsModal({
     password: string | null;
     originalName: string | null;
     type: string | null;
+    public: boolean;
   }>({
     name: file?.name ?? '',
     maxViews: file?.maxViews ?? null,
     password: file?.password ? '' : null,
     originalName: file?.originalName ?? null,
     type: file?.type ?? null,
+    public: file?.public ?? false,
   });
 
   useEffect(() => {
@@ -38,6 +40,7 @@ export default function EditFileDetailsModal({
         password: file?.password ? '' : null,
         originalName: file?.originalName ?? null,
         type: file?.type ?? null,
+        public: file?.public ?? false,
       });
     } else {
       setFormData({
@@ -46,6 +49,7 @@ export default function EditFileDetailsModal({
         password: null,
         originalName: null,
         type: null,
+        public: false,
       });
     }
   }, [open, file]);
@@ -85,12 +89,14 @@ export default function EditFileDetailsModal({
       originalName?: string;
       type?: string;
       name?: string;
+      public?: boolean;
     } = {};
 
     if (formData.maxViews !== null) data['maxViews'] = formData.maxViews;
     if (formData.originalName !== null) data['originalName'] = formData.originalName?.trim();
     if (formData.type !== null) data['type'] = formData.type?.trim();
     if (formData.name !== file.name) data['name'] = formData.name.trim();
+    if (formData.public !== file.public) data['public'] = formData.public;
 
     const passwordTrimmed = formData.password?.trim();
     if (passwordTrimmed !== '') data['password'] = passwordTrimmed;
@@ -167,6 +173,13 @@ export default function EditFileDetailsModal({
             )
           }
           c='red'
+        />
+
+        <Switch
+          label='Public File'
+          description='Show this file on your public profile gallery.'
+          checked={formData.public || false}
+          onChange={(event) => setFormData('public', event.currentTarget.checked)}
         />
 
         <Divider />

--- a/src/components/file/DashboardFile/FileModal.tsx
+++ b/src/components/file/DashboardFile/FileModal.tsx
@@ -237,7 +237,7 @@ export default function FileModal({
       >
         {file ? (
           <>
-            {open && <DashboardFileType file={file} show />}
+            {open && <DashboardFileType file={file} show forceRaw={reduce} />}
 
             <SimpleGrid cols={{ base: 1, md: 2, lg: 3 }} spacing='md' my='xs'>
               <FileStat Icon={IconFileInfo} title='Type' value={file.type} />

--- a/src/components/file/DashboardFile/FileViewer.tsx
+++ b/src/components/file/DashboardFile/FileViewer.tsx
@@ -567,6 +567,7 @@ export default function FileViewer({
                 fullscreen
                 allowZoom={false}
                 scrollParent={scrollParent}
+                forceRaw={reduce}
               />
 
               {sequenced && fileNavButtons && file && (

--- a/src/components/file/DashboardFileType/index.tsx
+++ b/src/components/file/DashboardFileType/index.tsx
@@ -62,6 +62,7 @@ export default function DashboardFileType({
   allowZoom,
   fullscreen,
   scrollParent,
+  forceRaw,
 }: {
   file: DbFile | File;
   show?: boolean;
@@ -70,11 +71,11 @@ export default function DashboardFileType({
   allowZoom?: boolean;
   fullscreen?: boolean;
   scrollParent?: HTMLElement | null;
+  forceRaw?: boolean;
 }) {
   const disableMediaPreview = useSettingsStore((state) => state.settings.disableMediaPreview);
-  const mediaAutoMuted = useSettingsStore((state) => state.settings.mediaAutoMuted);
 
-  const { fileUrl, thumbnailUrl, viewUrl } = useFileUrls({ file, token });
+  const { fileUrl, thumbnailUrl, viewUrl } = useFileUrls({ file, token, forceRaw });
   const db = isDbFile(file) ? file : null;
 
   const extension = file.name.split('.').pop() || '';
@@ -144,7 +145,8 @@ export default function DashboardFileType({
       <video
         width={fullscreen ? undefined : '100%'}
         autoPlay
-        muted={mediaAutoMuted}
+        loop
+        muted={false}
         controls
         src={fileUrl}
         style={{
@@ -209,7 +211,7 @@ export default function DashboardFileType({
   if (type === 'audio') {
     if (!fileUrl) return <Loader />;
     return show ? (
-      <audio autoPlay muted={mediaAutoMuted} controls style={{ width: '100%' }} src={fileUrl} />
+      <audio autoPlay loop muted={false} controls style={{ width: '100%' }} src={fileUrl} />
     ) : (
       <Placeholder text={`Click to play audio ${file.name}`} Icon={fileIcon(file.type)} />
     );
@@ -240,13 +242,15 @@ export default function DashboardFileType({
 
     return (
       <FullscreenFrame fullscreen={fullscreen} parent={scrollParent}>
-        <Render
-          mode={renderIn}
-          language={extension}
-          code={fileContent}
-          noClamp={fullscreen}
-          scrollParent={scrollParent}
-        />
+        <div className='selectable-text'>
+          <Render
+            mode={renderIn}
+            language={extension}
+            code={fileContent}
+            noClamp={fullscreen}
+            scrollParent={scrollParent}
+          />
+        </div>
       </FullscreenFrame>
     );
   }

--- a/src/components/file/DashboardFileType/useFileUrls.ts
+++ b/src/components/file/DashboardFileType/useFileUrls.ts
@@ -12,7 +12,15 @@ export function isDbFile(file: DbFile | File): file is DbFile {
   return typeof globalThis.File !== 'undefined' ? !(file instanceof globalThis.File) : 'thumbnail' in file;
 }
 
-export default function useFileUrls({ file, token }: { file: DbFile | File; token?: string | null }): {
+export default function useFileUrls({
+  file,
+  token,
+  forceRaw,
+}: {
+  file: DbFile | File;
+  token?: string | null;
+  forceRaw?: boolean;
+}): {
   fileUrl: string;
   thumbnailUrl: string | null;
   viewUrl: string | null;
@@ -25,12 +33,13 @@ export default function useFileUrls({ file, token }: { file: DbFile | File; toke
     if (!isDbFile(file)) return { fileUrl: blobUrl ?? '', thumbnailUrl: null, viewUrl: null };
 
     const thumb = file.thumbnail?.path;
-    const thumbnailUrl = thumb ? (user ? `/api/user/files/${thumb}/raw` : `/raw/${thumb}`) : null;
+    const useUserApi = user && !forceRaw;
+    const thumbnailUrl = thumb ? (useUserApi ? `/api/user/files/${thumb}/raw` : `/raw/${thumb}`) : null;
 
     return {
-      fileUrl: appendToken(user ? `/api/user/files/${file.id}/raw` : `/raw/${file.name}`, token),
+      fileUrl: appendToken(useUserApi ? `/api/user/files/${file.id}/raw` : `/raw/${file.name}`, token),
       viewUrl: appendToken(`/view/${file.name}`, token),
       thumbnailUrl,
     };
-  }, [token, blobUrl, file, user]);
+  }, [token, blobUrl, file, user, forceRaw]);
 }

--- a/src/components/pages/files/views/FilesTableView.tsx
+++ b/src/components/pages/files/views/FilesTableView.tsx
@@ -366,6 +366,12 @@ export default function FileTable({
       title: 'Anonymous?',
       render: (file: File) => (file.anonymous ? <Text c='green'>Yes</Text> : 'No'),
     },
+    {
+      accessor: 'public',
+      sortable: true,
+      title: 'Public?',
+      render: (file: File) => (file.public ? <Text c='blue'>Yes</Text> : 'No'),
+    },
   ];
 
   const visibleFields = fields.filter((f) => f.visible).map((f) => f.field);

--- a/src/components/pages/settings/index.tsx
+++ b/src/components/pages/settings/index.tsx
@@ -6,6 +6,7 @@ import { lazy } from 'react';
 const SettingsAvatar = lazy(() => import('./parts/SettingsAvatar'));
 const SettingsDashboard = lazy(() => import('./parts/SettingsDashboard'));
 const SettingsFileView = lazy(() => import('./parts/SettingsFileView'));
+const SettingsPublicProfile = lazy(() => import('./parts/SettingsPublicProfile'));
 const SettingsGenerators = lazy(() => import('./parts/SettingsGenerators'));
 const SettingsMfa = lazy(() => import('./parts/SettingsMfa'));
 const SettingsUser = lazy(() => import('./parts/SettingsUser'));
@@ -33,6 +34,8 @@ export default function DashboardSettings() {
         </Stack>
 
         <SettingsFileView />
+
+        <SettingsPublicProfile />
 
         {eitherTrue(
           config.oauthEnabled.discord,

--- a/src/components/pages/settings/parts/SettingsFileView.tsx
+++ b/src/components/pages/settings/parts/SettingsFileView.tsx
@@ -65,6 +65,9 @@ function Form({ user, setUser }: { user: User; setUser: (u: User) => void }) {
       embedDescription: user.view.embedDescription || '',
       embedSiteName: user.view.embedSiteName || '',
       embedColor: user.view.embedColor || '',
+      embedAuthor: user.view.embedAuthor || '',
+      embedAuthorUrl: user.view.embedAuthorUrl || '',
+      embedProviderUrl: user.view.embedProviderUrl || '',
       align: user.view.align || 'left',
       showMimetype: user.view.showMimetype || false,
       showTags: user.view.showTags || false,
@@ -82,6 +85,9 @@ function Form({ user, setUser }: { user: User; setUser: (u: User) => void }) {
       embedDescription: values.embedDescription.trim() || null,
       embedSiteName: values.embedSiteName.trim() || null,
       embedColor: values.embedColor.trim() || null,
+      embedAuthor: values.embedAuthor.trim() || null,
+      embedAuthorUrl: values.embedAuthorUrl.trim() || null,
+      embedProviderUrl: values.embedProviderUrl.trim() || null,
       align: values.align,
       showMimetype: values.showMimetype,
       showTags: values.showTags,
@@ -207,25 +213,151 @@ function Form({ user, setUser }: { user: User; setUser: (u: User) => void }) {
           <SimpleGrid cols={{ base: 1, md: 2 }} spacing='sm'>
             <TextInput
               label='Embed Title'
+              description='The bold linked title. Leave blank to use the filename.'
               disabled={!form.values.embed || !form.values.enabled}
               {...form.getInputProps('embedTitle')}
             />
             <TextInput
               label='Embed Description'
+              description='Text shown below the title.'
               disabled={!form.values.embed || !form.values.enabled}
               {...form.getInputProps('embedDescription')}
             />
             <TextInput
               label='Embed Site Name'
+              description='Provider/site label shown at the top. Leave blank for "Zipline".'
               disabled={!form.values.embed || !form.values.enabled}
               {...form.getInputProps('embedSiteName')}
             />
+            <TextInput
+              label='Embed Author'
+              description='Clickable name shown below the site name. Leave blank to use your username.'
+              disabled={!form.values.embed || !form.values.enabled}
+              {...form.getInputProps('embedAuthor')}
+            />
+            <TextInput
+              label='Embed Author URL'
+              description='The URL the author name links to. Leave blank to use your profile URL.'
+              disabled={!form.values.embed || !form.values.enabled}
+              {...form.getInputProps('embedAuthorUrl')}
+            />
+            <TextInput
+              label='Embed Provider URL'
+              description='The URL the provider/site name links to. Leave blank to use the site host.'
+              disabled={!form.values.embed || !form.values.enabled}
+              {...form.getInputProps('embedProviderUrl')}
+            />
             <ColorInput
               label='Embed Color'
+              description='The accent stripe color on the left of the embed.'
               disabled={!form.values.embed || !form.values.enabled}
               {...form.getInputProps('embedColor')}
             />
           </SimpleGrid>
+
+          {form.values.embed && form.values.enabled && (
+            <Stack gap='xs' mt='md'>
+              <Text size='sm' fw={500}>
+                Live Discord Embed Preview
+              </Text>
+              <Paper
+                p='md'
+                radius='sm'
+                style={{
+                  backgroundColor: '#313338',
+                  color: '#dbdee1',
+                  fontFamily: 'gg sans, "Segoe UI", Tahoma, sans-serif',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    backgroundColor: '#2b2d31',
+                    borderRadius: '4px',
+                    borderLeft: `4px solid ${form.values.embedColor || '#202225'}`,
+                    padding: '12px 16px',
+                    maxWidth: '520px',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', width: '100%' }}>
+                    {/* Provider */}
+                    <span style={{ fontSize: '12px', color: '#b5bac1', lineHeight: '16px' }}>
+                      {parsePreviewText(form.values.embedSiteName, user.username) || 'Zipline'}
+                    </span>
+
+                    {/* Author */}
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 600,
+                        color: '#00a8fc',
+                        lineHeight: '18px',
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
+                      onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}
+                    >
+                      {parsePreviewText(form.values.embedAuthor, user.username) || user.username}
+                    </span>
+
+                    {/* Title */}
+                    <span
+                      style={{
+                        fontSize: '16px',
+                        fontWeight: 600,
+                        color: '#00a8fc',
+                        lineHeight: '22px',
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
+                      onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}
+                    >
+                      {parsePreviewText(form.values.embedTitle, user.username) || 'image.png'}
+                    </span>
+
+                    {/* Description */}
+                    {form.values.embedDescription && (
+                      <span
+                        style={{
+                          fontSize: '14px',
+                          color: '#dbdee1',
+                          lineHeight: '18px',
+                          marginTop: '4px',
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {parsePreviewText(form.values.embedDescription, user.username)}
+                      </span>
+                    )}
+
+                    {/* Mock Image Preview */}
+                    <div
+                      style={{
+                        marginTop: '8px',
+                        borderRadius: '4px',
+                        overflow: 'hidden',
+                        maxWidth: '400px',
+                        aspectRatio: '16/9',
+                        backgroundColor: '#1e1f22',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        border: '1px solid #232428',
+                        color: '#949ba4',
+                        fontSize: '13px',
+                      }}
+                    >
+                      <span style={{ fontWeight: 600 }}>Video / Image Preview</span>
+                      <span style={{ fontSize: '11px', color: '#80848e', marginTop: '2px' }}>
+                        Media content renders here in Discord
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </Paper>
+            </Stack>
+          )}
 
           <Group justify='left' mt='sm'>
             <Button type='submit' leftSection={<IconDeviceFloppy size='1rem' />}>
@@ -236,4 +368,16 @@ function Form({ user, setUser }: { user: User; setUser: (u: User) => void }) {
       </Stack>
     </Paper>
   );
+}
+
+function parsePreviewText(str: string, username: string) {
+  if (!str) return '';
+  return str
+    .replace(/{file\.name}/gi, 'image.png')
+    .replace(/{file\.originalName}/gi, 'original_image.png')
+    .replace(/{file\.size}/gi, '1.2 MB')
+    .replace(/{file\.type}/gi, 'image/png')
+    .replace(/{user\.username}/gi, username || 'diced')
+    .replace(/{user\.role}/gi, 'ADMIN')
+    .replace(/{file\.views}/gi, '42');
 }

--- a/src/components/pages/settings/parts/SettingsPublicProfile.tsx
+++ b/src/components/pages/settings/parts/SettingsPublicProfile.tsx
@@ -1,0 +1,386 @@
+import type { User } from '@/lib/db/models/user';
+import { Response } from '@/lib/api/response';
+import { fetchApi } from '@/lib/fetchApi';
+import { useUserStore } from '@/lib/client/store/user';
+import {
+  Avatar,
+  Box,
+  Button,
+  FileButton,
+  Group,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  Title,
+  Textarea,
+  Divider,
+  Tabs,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import {
+  IconCheck,
+  IconDeviceFloppy,
+  IconExternalLink,
+  IconLink,
+  IconPencil,
+  IconPhotoUp,
+  IconTrash,
+  IconUpload,
+  IconUserCircle,
+} from '@tabler/icons-react';
+import { mutate } from 'swr';
+import { useShallow } from 'zustand/shallow';
+import { readToDataURL } from '@/lib/base64';
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+
+export default function SettingsPublicProfile() {
+  const [user, setUser] = useUserStore(useShallow((state) => [state.user, state.setUser]));
+
+  if (!user) {
+    return (
+      <Paper withBorder p='sm'>
+        <Title order={2}>Public Profile Settings</Title>
+        <p>Loading…</p>
+      </Paper>
+    );
+  }
+
+  return <Form user={user} setUser={setUser} />;
+}
+
+function Form({ user, setUser }: { user: User; setUser: (u: User) => void }) {
+  const [bannerUrl, setBannerUrl] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState('');
+
+  const form = useForm({
+    initialValues: {
+      bio: user.view.bio ?? '',
+      publicShowTotalViews: user.view.publicShowTotalViews !== false,
+      publicShowTotalUploads: user.view.publicShowTotalUploads !== false,
+      publicShowPrivateStats: user.view.publicShowPrivateStats !== false,
+      publicShowPublicStats: user.view.publicShowPublicStats !== false,
+    },
+  });
+
+  const onSubmit = async (values: typeof form.values) => {
+    const { data, error } = await fetchApi<Response['/api/user']>('/api/user', 'PATCH', {
+      view: {
+        bio: values.bio || null,
+        publicShowTotalViews: values.publicShowTotalViews,
+        publicShowTotalUploads: values.publicShowTotalUploads,
+        publicShowPrivateStats: values.publicShowPrivateStats,
+        publicShowPublicStats: values.publicShowPublicStats,
+      },
+    });
+
+    if (!data && error) {
+      notifications.show({
+        title: 'Error while updating settings',
+        message: error.error,
+        color: 'red',
+        icon: <IconUserCircle size='1rem' />,
+      });
+      return;
+    }
+
+    if (!data?.user) return;
+
+    mutate('/api/user');
+    setUser(data.user);
+    notifications.show({
+      message: 'Public profile settings updated',
+      color: 'green',
+      icon: <IconCheck size='1rem' />,
+    });
+  };
+
+  // ── Banner helpers ──────────────────────────────────────────────────────────
+  const saveBanner = async (value: string | null, label = 'Banner') => {
+    const { data, error } = await fetchApi<Response['/api/user']>('/api/user', 'PATCH', {
+      view: { banner: value },
+    });
+    if (error || !data?.user) {
+      notifications.show({ title: `Failed to update ${label}`, message: error?.error, color: 'red' });
+    } else {
+      mutate('/api/user');
+      setUser(data.user);
+      notifications.show({ message: `${label} updated!`, color: 'green' });
+    }
+  };
+
+  const handleBannerUpload = async (file: File | null) => {
+    if (!file) return;
+    const base64url = await readToDataURL(file);
+    await saveBanner(base64url, 'Banner');
+  };
+
+  const handleBannerUrl = async () => {
+    const url = bannerUrl.trim();
+    if (!url) return;
+    // Store as a plain URL — the banner endpoint will detect data-URL vs plain URL
+    await saveBanner(url, 'Banner');
+    setBannerUrl('');
+  };
+
+  const handleBannerRemove = () => saveBanner(null, 'Banner');
+
+  // ── Avatar helpers ──────────────────────────────────────────────────────────
+  const saveAvatar = async (value: string | null, label = 'Avatar') => {
+    const { data, error } = await fetchApi<Response['/api/user']>('/api/user', 'PATCH', {
+      avatar: value,
+    });
+    if (error || !data?.user) {
+      notifications.show({ title: `Failed to update ${label}`, message: error?.error, color: 'red' });
+    } else {
+      mutate('/api/user');
+      setUser(data.user);
+      notifications.show({ message: `${label} updated!`, color: 'green' });
+    }
+  };
+
+  const handleAvatarUpload = async (file: File | null) => {
+    if (!file) return;
+    const base64url = await readToDataURL(file);
+    await saveAvatar(base64url, 'Avatar');
+  };
+
+  const handleAvatarUrl = async () => {
+    const url = avatarUrl.trim();
+    if (!url) return;
+    await saveAvatar(url, 'Avatar');
+    setAvatarUrl('');
+  };
+
+  const handleAvatarRemove = () => saveAvatar(null, 'Avatar');
+
+  // Banner preview: raw base64 or plain URL both work in CSS
+  const bannerPreview = user.view.banner
+    ? user.view.banner.startsWith('data:')
+      ? `url(${user.view.banner})`
+      : `url(${user.view.banner})`
+    : null;
+
+  return (
+    <Paper withBorder p='sm'>
+      <Group justify='space-between' mb='md'>
+        <Title order={2}>Public Profile Settings</Title>
+        <Button
+          component={Link}
+          to={`/user/${user.username}`}
+          variant='light'
+          leftSection={<IconExternalLink size='1rem' />}
+          size='sm'
+        >
+          Open My Profile
+        </Button>
+      </Group>
+
+      {/* ── Banner Section ─────────────────────────────────────────────────── */}
+      <Stack gap='xs' mb='md'>
+        <Text fw={500} size='sm'>
+          Profile Banner
+        </Text>
+        <Box
+          style={{
+            borderRadius: 8,
+            overflow: 'hidden',
+            height: 120,
+            background: bannerPreview
+              ? `${bannerPreview} no-repeat center/cover`
+              : 'linear-gradient(135deg, var(--mantine-color-blue-filled) 0%, var(--mantine-color-indigo-filled) 100%)',
+            border: '1px solid var(--mantine-color-default-border)',
+          }}
+        />
+        <Tabs defaultValue='upload' variant='outline'>
+          <Tabs.List mb='xs'>
+            <Tabs.Tab value='upload' leftSection={<IconUpload size='0.8rem' />}>
+              Upload file
+            </Tabs.Tab>
+            <Tabs.Tab value='url' leftSection={<IconLink size='0.8rem' />}>
+              Image URL
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value='upload'>
+            <Group gap='xs'>
+              <FileButton onChange={handleBannerUpload} accept='image/*'>
+                {(props) => (
+                  <Button {...props} size='xs' variant='light' leftSection={<IconPhotoUp size='0.8rem' />}>
+                    Upload Banner
+                  </Button>
+                )}
+              </FileButton>
+              {user.view.banner && (
+                <Button
+                  size='xs'
+                  variant='light'
+                  color='red'
+                  leftSection={<IconTrash size='0.8rem' />}
+                  onClick={handleBannerRemove}
+                >
+                  Remove Banner
+                </Button>
+              )}
+            </Group>
+          </Tabs.Panel>
+
+          <Tabs.Panel value='url'>
+            <Group gap='xs' align='flex-end'>
+              <TextInput
+                placeholder='https://example.com/banner.gif'
+                value={bannerUrl}
+                onChange={(e) => setBannerUrl(e.currentTarget.value)}
+                style={{ flex: 1 }}
+                size='xs'
+              />
+              <Button size='xs' variant='light' onClick={handleBannerUrl} disabled={!bannerUrl.trim()}>
+                Set Banner
+              </Button>
+              {user.view.banner && (
+                <Button
+                  size='xs'
+                  variant='light'
+                  color='red'
+                  leftSection={<IconTrash size='0.8rem' />}
+                  onClick={handleBannerRemove}
+                >
+                  Remove
+                </Button>
+              )}
+            </Group>
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+
+      {/* ── Avatar Section ─────────────────────────────────────────────────── */}
+      <Stack gap='xs' mb='md'>
+        <Text fw={500} size='sm'>
+          Profile Avatar
+        </Text>
+        <Group gap='sm' align='flex-start'>
+          <Avatar
+            src={user.avatar || null}
+            size={64}
+            radius={64}
+            style={{ border: '3px solid var(--mantine-color-default-border)', flexShrink: 0 }}
+          />
+          <Tabs defaultValue='upload' variant='outline' style={{ flex: 1 }}>
+            <Tabs.List mb='xs'>
+              <Tabs.Tab value='upload' leftSection={<IconUpload size='0.8rem' />}>
+                Upload file
+              </Tabs.Tab>
+              <Tabs.Tab value='url' leftSection={<IconLink size='0.8rem' />}>
+                Image URL
+              </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value='upload'>
+              <Group gap='xs'>
+                <FileButton onChange={handleAvatarUpload} accept='image/*'>
+                  {(props) => (
+                    <Button {...props} size='xs' variant='light' leftSection={<IconPencil size='0.8rem' />}>
+                      Change Avatar
+                    </Button>
+                  )}
+                </FileButton>
+                {user.avatar && (
+                  <Button
+                    size='xs'
+                    variant='light'
+                    color='red'
+                    leftSection={<IconTrash size='0.8rem' />}
+                    onClick={handleAvatarRemove}
+                  >
+                    Remove Avatar
+                  </Button>
+                )}
+              </Group>
+            </Tabs.Panel>
+
+            <Tabs.Panel value='url'>
+              <Group gap='xs' align='flex-end'>
+                <TextInput
+                  placeholder='https://example.com/avatar.gif'
+                  value={avatarUrl}
+                  onChange={(e) => setAvatarUrl(e.currentTarget.value)}
+                  style={{ flex: 1 }}
+                  size='xs'
+                />
+                <Button size='xs' variant='light' onClick={handleAvatarUrl} disabled={!avatarUrl.trim()}>
+                  Set Avatar
+                </Button>
+                {user.avatar && (
+                  <Button
+                    size='xs'
+                    variant='light'
+                    color='red'
+                    leftSection={<IconTrash size='0.8rem' />}
+                    onClick={handleAvatarRemove}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </Group>
+            </Tabs.Panel>
+          </Tabs>
+        </Group>
+      </Stack>
+
+      <Divider mb='md' />
+
+      <form onSubmit={form.onSubmit(onSubmit)}>
+        <Stack gap='sm'>
+          <Textarea
+            label='Bio'
+            placeholder='Write a short bio...'
+            description='Shown on your public profile page. Supports Markdown. Links open in a new tab.'
+            maxRows={4}
+            autosize
+            {...form.getInputProps('bio')}
+          />
+
+          <Title order={3} mt='sm'>
+            Statistics Visibility
+          </Title>
+
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing='sm'>
+            <Switch
+              label='Show Total Views'
+              description='Show sum of views for all files on your public profile'
+              {...form.getInputProps('publicShowTotalViews', { type: 'checkbox' })}
+            />
+
+            <Switch
+              label='Show Total Uploads'
+              description='Show count of all files uploaded on your public profile'
+              {...form.getInputProps('publicShowTotalUploads', { type: 'checkbox' })}
+            />
+
+            <Switch
+              label='Show Public Files Count'
+              description='Show how many of your files are public'
+              {...form.getInputProps('publicShowPublicStats', { type: 'checkbox' })}
+            />
+
+            <Switch
+              label='Show Private Files Count'
+              description='Show how many of your files are private'
+              {...form.getInputProps('publicShowPrivateStats', { type: 'checkbox' })}
+            />
+          </SimpleGrid>
+
+          <Group justify='left' mt='sm'>
+            <Button type='submit' leftSection={<IconDeviceFloppy size='1rem' />}>
+              Save Settings
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Paper>
+  );
+}

--- a/src/components/render/Markdown.tsx
+++ b/src/components/render/Markdown.tsx
@@ -1,24 +1,74 @@
 import { Paper, Typography } from '@mantine/core';
-import Marked from 'marked-react';
-import HighlightCode from './code/HighlightCode';
-import { sanitize } from 'isomorphic-dompurify';
+import { Marked, Renderer } from 'marked';
+import hljs from 'highlight.js';
+import DOMPurify from 'isomorphic-dompurify';
 
-const components = {
-  code(value: string, language?: string) {
-    return <HighlightCode code={value} language={language ?? 'text'} />;
-  },
+const renderer = new Renderer();
+
+renderer.code = function ({ text, lang }) {
+  const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+  let highlighted: string;
+  try {
+    highlighted = hljs.highlight(text, { language }).value;
+  } catch {
+    highlighted = text;
+  }
+  return `<pre><code class="hljs language-${language}">${highlighted}</code></pre>`;
 };
 
-export default function Markdown({ md }: { md: string }) {
-  const cleanedMd = sanitize(md, {
-    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br', 'code', 'pre', 'span'],
-    ALLOWED_ATTR: ['href', 'title', 'class'],
-  });
+renderer.link = function ({ href, title, tokens }) {
+  const text = this.parser.parseInline(tokens);
+  let linkStr = `<a href="${href}"`;
+  if (title) linkStr += ` title="${title}"`;
+  linkStr += ' target="_blank" rel="noopener noreferrer"';
+  linkStr += `>${text}</a>`;
+  return linkStr;
+};
+
+renderer.image = function ({ href, title, text }) {
+  let imgStr = `<img src="${href}" alt="${text || ''}"`;
+  if (title) imgStr += ` title="${title}"`;
+  imgStr +=
+    ' loading="lazy" style="max-width: 100%; vertical-align: middle;" draggable="false" ondragstart="event.preventDefault()"';
+  imgStr += '>';
+  return imgStr;
+};
+
+const customMarked = new Marked({ renderer });
+
+// Add hook for absolute safety enforcing target="_blank" on a, and draggable="false" on media
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A') {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+  if (node.tagName === 'IMG' || node.tagName === 'VIDEO') {
+    node.setAttribute('draggable', 'false');
+  }
+});
+
+export default function Markdown({ md, plain }: { md: string; plain?: boolean }) {
+  // Compile markdown to raw HTML (runs synchronously)
+  const rawHtml = customMarked.parse(md || '') as string;
+
+  // Sanitize raw HTML string (allowing safe tags/attributes/styles, excluding scripts)
+  const cleanHtml = DOMPurify.sanitize(rawHtml, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ['script'],
+  }) as string;
+
+  if (plain) {
+    return (
+      <Typography>
+        <div dangerouslySetInnerHTML={{ __html: cleanHtml }} />
+      </Typography>
+    );
+  }
 
   return (
     <Paper withBorder p='md'>
       <Typography>
-        <Marked value={cleanedMd} gfm renderer={components} />
+        <div dangerouslySetInnerHTML={{ __html: cleanHtml }} />
       </Typography>
     </Paper>
   );

--- a/src/lib/client/store/fileTableSettings.ts
+++ b/src/lib/client/store/fileTableSettings.ts
@@ -10,7 +10,8 @@ type Field =
   | 'createdAt'
   | 'favorite'
   | 'views'
-  | 'anonymous';
+  | 'anonymous'
+  | 'public';
 
 const FIELDS: {
   property: Field;
@@ -26,6 +27,7 @@ const FIELDS: {
   { property: 'favorite', visible: true, title: 'Favorite' },
   { property: 'views', visible: true, title: 'Views' },
   { property: 'anonymous', visible: false, title: 'Anonymous?' },
+  { property: 'public', visible: false, title: 'Public?' },
 ];
 
 export const defaultFields: FieldSettings[] = FIELDS.map(({ property, visible }) => ({

--- a/src/lib/db/models/file.ts
+++ b/src/lib/db/models/file.ts
@@ -17,6 +17,9 @@ export const fileSelect = {
   maxViews: true,
   folderId: true,
   anonymous: true,
+  public: true,
+  width: true,
+  height: true,
   thumbnail: {
     select: {
       path: true,
@@ -67,6 +70,9 @@ export const fileSchema = z.object({
   password: z.union([z.string(), z.boolean()]).nullish(),
   folderId: z.string().nullable(),
   anonymous: z.boolean().nullish(),
+  public: z.boolean().nullish(),
+  width: z.number().nullable().optional(),
+  height: z.number().nullable().optional(),
 
   thumbnail: z
     .object({

--- a/src/lib/db/models/user.ts
+++ b/src/lib/db/models/user.ts
@@ -28,6 +28,15 @@ export const userViewSchema = z
     embedDescription: z.string().nullish(),
     embedColor: z.string().nullish(),
     embedSiteName: z.string().nullish(),
+    embedAuthor: z.string().nullish(),
+    embedAuthorUrl: z.string().nullish(),
+    embedProviderUrl: z.string().nullish(),
+    banner: z.string().nullish(),
+    bio: z.string().nullish(),
+    publicShowTotalViews: z.boolean().nullish(),
+    publicShowTotalUploads: z.boolean().nullish(),
+    publicShowPrivateStats: z.boolean().nullish(),
+    publicShowPublicStats: z.boolean().nullish(),
   })
   .partial();
 

--- a/src/offload/partial.ts
+++ b/src/offload/partial.ts
@@ -15,6 +15,37 @@ import { open, readdir, rm } from 'fs/promises';
 import { join } from 'path';
 import { isMainThread, workerData } from 'worker_threads';
 import { dbProxy } from './proxiedDb';
+import sharp from 'sharp';
+import ffmpeg from 'fluent-ffmpeg';
+
+async function getImageDimensions(path: string): Promise<{ width: number; height: number } | null> {
+  try {
+    const metadata = await sharp(path).metadata();
+    if (metadata.width && metadata.height) {
+      return { width: metadata.width, height: metadata.height };
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function getVideoDimensions(path: string): Promise<{ width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    ffmpeg.ffprobe(path, (err, metadata) => {
+      if (err || !metadata) {
+        resolve(null);
+        return;
+      }
+      const stream = metadata.streams.find((s) => s.codec_type === 'video');
+      if (stream && stream.width && stream.height) {
+        resolve({ width: stream.width, height: stream.height });
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
 
 export type PartialWorkerData = {
   user: {
@@ -194,12 +225,34 @@ async function runComplete(id: string) {
   });
   if (!userr) return;
 
+  // Extract dimensions from the assembled file
+  let width: number | null = null;
+  let height: number | null = null;
+
+  if (finalPath) {
+    if (file.type.startsWith('image/')) {
+      const dims = await getImageDimensions(finalPath);
+      if (dims) {
+        width = dims.width;
+        height = dims.height;
+      }
+    } else if (file.type.startsWith('video/')) {
+      const dims = await getVideoDimensions(finalPath);
+      if (dims) {
+        width = dims.width;
+        height = dims.height;
+      }
+    }
+  }
+
   const fileUpload = await dbProxy<File>('file.update', {
     where: {
       id,
     },
     data: {
       size: options.partial!.range[2],
+      ...(width !== null && { width }),
+      ...(height !== null && { height }),
       ...(options.maxViews && { maxViews: options.maxViews }),
       ...(options.deletesAt && options.deletesAt !== 'never'
         ? { deletesAt: options.deletesAt }

--- a/src/server/plugins/vite.ts
+++ b/src/server/plugins/vite.ts
@@ -10,6 +10,7 @@ import { renderHtml } from '@/lib/ssr/renderHtml';
 import { readThemes } from '@/lib/theme/file';
 import { ZIPLINE_SSR_INSERT, ZIPLINE_SSR_META } from '@/lib/ssr/constants';
 import { log } from '@/lib/logger';
+import { prisma } from '@/lib/db';
 
 export const ALL_METHODS: HTTPMethods[] = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'];
 
@@ -18,6 +19,7 @@ const logger = log('server').c('plugin').c('vite');
 
 async function vitePlugin(fastify: FastifyInstance) {
   fastify.decorateReply('ssr', ssrRoute);
+  fastify.decorateReply('serveProfile', serveProfile);
 
   if (MODE === 'production') {
     fastify.decorate('serveIndex', route);
@@ -117,6 +119,90 @@ async function vitePlugin(fastify: FastifyInstance) {
   async function serveIndex(this: FastifyReply) {
     return this.sendFile('index.html', resolve('./build/client'));
   }
+
+  async function serveProfile(this: FastifyReply, username: string) {
+    const url = this.request.raw.url || '/';
+
+    try {
+      const user = await prisma.user.findFirst({
+        where: {
+          username: {
+            equals: username,
+            mode: 'insensitive',
+          },
+        },
+        select: {
+          username: true,
+          avatar: true,
+          view: true,
+        },
+      });
+
+      if (!user) return this.callNotFound();
+
+      let template: string;
+      if (MODE === 'development' && fastify.vite) {
+        template = await readFile(resolve('./src/client/index.html'), 'utf-8');
+        template = await fastify.vite.transformIndexHtml(url, template);
+      } else {
+        template = await readFile(resolve('./build/client/index.html'), 'utf-8');
+      }
+
+      const view = (user.view || {}) as any;
+      const bioText = view.bio || '';
+      const hasAvatar = !!user.avatar;
+
+      let host = this.request.headers.host || 'localhost';
+      const proto = this.request.headers['x-forwarded-proto'];
+      try {
+        if (
+          JSON.parse(this.request.headers['cf-visitor'] as string)?.scheme === 'https' ||
+          proto === 'https' ||
+          config.core.returnHttpsUrls
+        ) {
+          host = `https://${host}`;
+        } else {
+          host = `http://${host}`;
+        }
+      } catch {
+        host = proto === 'https' || config.core.returnHttpsUrls ? `https://${host}` : `http://${host}`;
+      }
+
+      const pageUrl = `${host}${this.request.raw.url?.split('?')[0]}`;
+      // Use the dedicated image endpoint so og:image is a proper absolute URL (not inline base64)
+      const avatarUrl = hasAvatar ? `${host}/api/users/${user.username}/avatar` : '';
+      const cleanBioText = bioText
+        ? bioText
+            .replace(/<[^>]*>/g, '')
+            .replace(/[\n\r]+/g, ' ')
+            .replace(/"/g, '&quot;')
+            .slice(0, 160)
+        : '';
+
+      const metaTags = [
+        `<meta property="og:title" content="${user.username}'s Profile" />`,
+        cleanBioText
+          ? `<meta property="og:description" content="${cleanBioText}" />`
+          : `<meta property="og:description" content="View ${user.username}'s public gallery and uploads on Zipline" />`,
+        avatarUrl ? `<meta property="og:image" content="${avatarUrl}" />` : '',
+        `<meta property="og:url" content="${pageUrl}" />`,
+        '<meta property="og:type" content="profile" />',
+        '<meta name="twitter:card" content="summary" />',
+        avatarUrl ? `<meta name="twitter:image" content="${avatarUrl}" />` : '',
+      ]
+        .filter(Boolean)
+        .join('\n  ');
+
+      const finalHtml = template
+        .replace('<title>Zipline</title>', `<title>${user.username}'s Profile</title>`)
+        .replace('</head>', `${metaTags}\n</head>`);
+
+      return this.type('text/html').send(finalHtml);
+    } catch (err) {
+      console.error(err);
+      return this.internalServerError();
+    }
+  }
 }
 
 export default fastifyPlugin(vitePlugin, {
@@ -133,5 +219,6 @@ declare module 'fastify' {
   interface FastifyReply {
     ssr: (type: 'view-url' | 'view') => Promise<void>;
     serveIndex: () => Promise<void>;
+    serveProfile: (username: string) => Promise<void>;
   }
 }

--- a/src/server/routes/api/upload/index.ts
+++ b/src/server/routes/api/upload/index.ts
@@ -19,6 +19,37 @@ import typedPlugin from '@/server/typedPlugin';
 import { SavedMultipartFile } from '@fastify/multipart';
 import { stat } from 'fs/promises';
 import { z } from 'zod';
+import sharp from 'sharp';
+import ffmpeg from 'fluent-ffmpeg';
+
+async function getImageDimensions(path: string): Promise<{ width: number; height: number } | null> {
+  try {
+    const metadata = await sharp(path).metadata();
+    if (metadata.width && metadata.height) {
+      return { width: metadata.width, height: metadata.height };
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function getVideoDimensions(path: string): Promise<{ width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    ffmpeg.ffprobe(path, (err, metadata) => {
+      if (err || !metadata) {
+        resolve(null);
+        return;
+      }
+      const stream = metadata.streams.find((s) => s.codec_type === 'video');
+      if (stream && stream.width && stream.height) {
+        resolve({ width: stream.width, height: stream.height });
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
 
 export type ApiUploadResponse = {
   files: {
@@ -204,10 +235,29 @@ export default typedPlugin(
 
           const tempFileStats = await stat(file.filepath);
 
+          let width: number | null = null;
+          let height: number | null = null;
+
+          if (mimetype.startsWith('image/')) {
+            const dims = await getImageDimensions(file.filepath);
+            if (dims) {
+              width = dims.width;
+              height = dims.height;
+            }
+          } else if (mimetype.startsWith('video/')) {
+            const dims = await getVideoDimensions(file.filepath);
+            if (dims) {
+              width = dims.width;
+              height = dims.height;
+            }
+          }
+
           const data: Prisma.FileCreateInput = {
             name: `${fileName}${compressed ? '.' + compressed.ext : extension}`,
             size: compressed?.buffer?.length ?? tempFileStats.size,
             type: compressed?.mimetype ?? mimetype,
+            width,
+            height,
             User: { connect: { id: req.user ? req.user.id : options.folder ? folder?.userId : undefined } },
           };
 

--- a/src/server/routes/api/user/files/[id]/index.ts
+++ b/src/server/routes/api/user/files/[id]/index.ts
@@ -69,6 +69,7 @@ export default typedPlugin(
             tags: z.array(z.string()).optional(),
             name: z.string().trim().min(1).optional().transform(zValidatePath),
             anonymous: z.boolean().optional(),
+            public: z.boolean().optional(),
           }),
           response: {
             200: fileSchema,
@@ -95,6 +96,7 @@ export default typedPlugin(
         if (req.body.originalName !== undefined) data.originalName = req.body.originalName;
         if (req.body.type !== undefined) data.type = req.body.type;
         if (req.body.anonymous !== undefined) data.anonymous = req.body.anonymous;
+        if (req.body.public !== undefined) data.public = req.body.public;
 
         if (req.body.maxViews !== undefined) {
           data.maxViews = req.body.maxViews;

--- a/src/server/routes/api/user/index.ts
+++ b/src/server/routes/api/user/index.ts
@@ -57,11 +57,20 @@ export default typedPlugin(
                 embedDescription: z.string().nullish(),
                 embedColor: z.string().nullish(),
                 embedSiteName: z.string().nullish(),
+                embedAuthor: z.string().nullish(),
+                embedAuthorUrl: z.string().nullish(),
+                embedProviderUrl: z.string().nullish(),
                 enabled: z.boolean().optional(),
                 align: z.enum(['left', 'center', 'right']).optional(),
                 showMimetype: z.boolean().optional(),
                 showTags: z.boolean().optional(),
                 showFolder: z.boolean().optional(),
+                banner: z.string().nullish(),
+                bio: z.string().nullish(),
+                publicShowTotalViews: z.boolean().optional(),
+                publicShowTotalUploads: z.boolean().optional(),
+                publicShowPrivateStats: z.boolean().optional(),
+                publicShowPublicStats: z.boolean().optional(),
               })
               .partial()
               .optional(),
@@ -75,6 +84,7 @@ export default typedPlugin(
           tags: ['auth'],
         },
         preHandler: [userMiddleware],
+        bodyLimit: 100 * 1024 * 1024,
         ...secondlyRatelimit(1),
       },
       async (req, res) => {
@@ -122,6 +132,15 @@ export default typedPlugin(
                 ...(req.body.view.embedSiteName !== undefined && {
                   embedSiteName: req.body.view.embedSiteName || null,
                 }),
+                ...(req.body.view.embedAuthor !== undefined && {
+                  embedAuthor: req.body.view.embedAuthor || null,
+                }),
+                ...(req.body.view.embedAuthorUrl !== undefined && {
+                  embedAuthorUrl: req.body.view.embedAuthorUrl || null,
+                }),
+                ...(req.body.view.embedProviderUrl !== undefined && {
+                  embedProviderUrl: req.body.view.embedProviderUrl || null,
+                }),
                 ...(req.body.view.align !== undefined && { align: req.body.view.align || 'center' }),
                 ...(req.body.view.showMimetype !== undefined && {
                   showMimetype: req.body.view.showMimetype || false,
@@ -129,6 +148,20 @@ export default typedPlugin(
                 ...(req.body.view.showTags !== undefined && { showTags: req.body.view.showTags || false }),
                 ...(req.body.view.showFolder !== undefined && {
                   showFolder: req.body.view.showFolder || false,
+                }),
+                ...(req.body.view.banner !== undefined && { banner: req.body.view.banner || null }),
+                ...(req.body.view.bio !== undefined && { bio: req.body.view.bio || null }),
+                ...(req.body.view.publicShowTotalViews !== undefined && {
+                  publicShowTotalViews: req.body.view.publicShowTotalViews,
+                }),
+                ...(req.body.view.publicShowTotalUploads !== undefined && {
+                  publicShowTotalUploads: req.body.view.publicShowTotalUploads,
+                }),
+                ...(req.body.view.publicShowPrivateStats !== undefined && {
+                  publicShowPrivateStats: req.body.view.publicShowPrivateStats,
+                }),
+                ...(req.body.view.publicShowPublicStats !== undefined && {
+                  publicShowPublicStats: req.body.view.publicShowPublicStats,
                 }),
               },
             }),

--- a/src/server/routes/api/users/avatar.ts
+++ b/src/server/routes/api/users/avatar.ts
@@ -1,0 +1,52 @@
+import { ApiError } from '@/lib/api/errors';
+import { prisma } from '@/lib/db';
+import typedPlugin from '@/server/typedPlugin';
+import z from 'zod';
+
+export const PATH = '/api/users/:username/avatar';
+
+export default typedPlugin(
+  async (server) => {
+    server.get<{ Params: { username: string } }>(
+      PATH,
+      {
+        schema: {
+          description: "Return a user's public avatar as a binary image response.",
+          params: z.object({ username: z.string() }),
+          tags: ['users'],
+        },
+      },
+      async (req, res) => {
+        const { username } = req.params;
+
+        const user = await prisma.user.findFirst({
+          where: { username: { equals: username, mode: 'insensitive' } },
+          select: { avatar: true },
+        });
+
+        if (!user || !user.avatar) throw new ApiError(4000);
+
+        // Plain URL — redirect to the remote image
+        if (!user.avatar.startsWith('data:')) {
+          return res
+            .header('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+            .redirect(user.avatar);
+        }
+
+        // Parse the data URL: "data:<mime>;base64,<data>"
+        const match = user.avatar.match(/^data:([^;]+);base64,(.+)$/);
+        if (!match) throw new ApiError(4000);
+
+        const [, mime, b64] = match;
+        const buf = Buffer.from(b64, 'base64');
+
+        return res
+          .header('Content-Type', mime)
+          .header('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+          .header('Content-Length', buf.length)
+          .send(buf);
+      },
+    );
+  },
+  { name: PATH },
+);

--- a/src/server/routes/api/users/banner.ts
+++ b/src/server/routes/api/users/banner.ts
@@ -1,0 +1,57 @@
+import { ApiError } from '@/lib/api/errors';
+import { prisma } from '@/lib/db';
+import typedPlugin from '@/server/typedPlugin';
+import z from 'zod';
+
+export const PATH = '/api/users/:username/banner';
+
+export default typedPlugin(
+  async (server) => {
+    server.get<{ Params: { username: string } }>(
+      PATH,
+      {
+        schema: {
+          description: "Return a user's public profile banner as a binary image response.",
+          params: z.object({ username: z.string() }),
+          tags: ['users'],
+        },
+      },
+      async (req, res) => {
+        const { username } = req.params;
+
+        const user = await prisma.user.findFirst({
+          where: { username: { equals: username, mode: 'insensitive' } },
+          select: { view: true },
+        });
+
+        if (!user) throw new ApiError(4000);
+
+        const view = (user.view || {}) as { banner?: string | null };
+        const banner = view.banner;
+
+        if (!banner) throw new ApiError(4000);
+
+        // Plain URL — redirect to the remote image
+        if (!banner.startsWith('data:')) {
+          return res
+            .header('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+            .redirect(banner);
+        }
+
+        // Parse the data URL: "data:<mime>;base64,<data>"
+        const match = banner.match(/^data:([^;]+);base64,(.+)$/);
+        if (!match) throw new ApiError(4000);
+
+        const [, mime, b64] = match;
+        const buf = Buffer.from(b64, 'base64');
+
+        return res
+          .header('Content-Type', mime)
+          .header('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+          .header('Content-Length', buf.length)
+          .send(buf);
+      },
+    );
+  },
+  { name: PATH },
+);

--- a/src/server/routes/api/users/public.ts
+++ b/src/server/routes/api/users/public.ts
@@ -1,0 +1,156 @@
+import { ApiError } from '@/lib/api/errors';
+import { prisma } from '@/lib/db';
+import { cleanFiles } from '@/lib/db/models/file';
+import typedPlugin from '@/server/typedPlugin';
+import z from 'zod';
+
+const paramsSchema = z.object({
+  username: z.string(),
+});
+
+export const PATH = '/api/users/:username/public';
+
+export default typedPlugin(
+  async (server) => {
+    server.get(
+      PATH,
+      {
+        schema: {
+          description: 'Fetch public profile and gallery files for a user.',
+          params: paramsSchema,
+          response: {
+            200: z.object({
+              user: z.object({
+                username: z.string(),
+                avatar: z.string().nullable(),
+                banner: z.string().nullable().optional(),
+                bio: z.string().nullable().optional(),
+                createdAt: z.string(),
+                stats: z
+                  .object({
+                    totalViews: z.number().nullable(),
+                    totalUploads: z.number().nullable(),
+                    privateUploads: z.number().nullable(),
+                    publicUploads: z.number().nullable(),
+                  })
+                  .optional(),
+              }),
+              files: z.array(
+                z.object({
+                  id: z.string(),
+                  name: z.string(),
+                  originalName: z.string().nullable(),
+                  type: z.string(),
+                  size: z.union([z.number(), z.bigint()]),
+                  views: z.number(),
+                  createdAt: z.string(),
+                  url: z.string().optional(),
+                  thumbnail: z
+                    .object({
+                      path: z.string(),
+                    })
+                    .nullable()
+                    .optional(),
+                }),
+              ),
+            }),
+          },
+        },
+      },
+      async (req, res) => {
+        const { username } = req.params;
+
+        const user = await prisma.user.findFirst({
+          where: {
+            username: {
+              equals: username,
+              mode: 'insensitive',
+            },
+          },
+          select: {
+            id: true,
+            username: true,
+            avatar: true,
+            createdAt: true,
+            view: true,
+          },
+        });
+
+        if (!user) throw new ApiError(4000);
+
+        const view = (user.view || {}) as any;
+        const hasBanner = !!view.banner;
+        const bio = view.bio || null;
+
+        const showTotalViews = view.publicShowTotalViews !== false;
+        const showTotalUploads = view.publicShowTotalUploads !== false;
+        const showPrivateStats = view.publicShowPrivateStats !== false;
+        const showPublicStats = view.publicShowPublicStats !== false;
+
+        // Parallelise all queries
+        const [files, totalViewsResult, totalUploads, privateUploads, publicUploads] = await Promise.all([
+          prisma.file.findMany({
+            where: { userId: user.id, public: true },
+            orderBy: { createdAt: 'desc' },
+            select: {
+              id: true,
+              name: true,
+              originalName: true,
+              type: true,
+              size: true,
+              views: true,
+              createdAt: true,
+              thumbnail: {
+                select: {
+                  path: true,
+                },
+              },
+            },
+          }),
+          showTotalViews
+            ? prisma.file.aggregate({ where: { userId: user.id }, _sum: { views: true } })
+            : Promise.resolve(null),
+          showTotalUploads ? prisma.file.count({ where: { userId: user.id } }) : Promise.resolve(null),
+          showPrivateStats
+            ? prisma.file.count({ where: { userId: user.id, public: false } })
+            : Promise.resolve(null),
+          showPublicStats
+            ? prisma.file.count({ where: { userId: user.id, public: true } })
+            : Promise.resolve(null),
+        ]);
+
+        const cleanedFiles = cleanFiles(files as any, true);
+        const totalViews = (totalViewsResult as any)?._sum?.views ?? 0;
+
+        return res.send({
+          user: {
+            username: user.username,
+            // Return URL paths instead of raw base64 — browser can cache these
+            avatar: user.avatar ? `/api/users/${user.username}/avatar` : null,
+            banner: hasBanner ? `/api/users/${user.username}/banner` : null,
+            bio,
+            createdAt: user.createdAt.toISOString(),
+            stats: {
+              totalViews: showTotalViews ? Number(totalViews) : null,
+              totalUploads,
+              privateUploads,
+              publicUploads,
+            },
+          },
+          files: cleanedFiles.map((f: any) => ({
+            id: f.id,
+            name: f.name,
+            originalName: f.originalName,
+            type: f.type,
+            size: Number(f.size),
+            views: f.views,
+            createdAt: f.createdAt,
+            url: f.url,
+            thumbnail: f.thumbnail ? { path: f.thumbnail.path } : null,
+          })),
+        });
+      },
+    );
+  },
+  { name: PATH },
+);

--- a/src/server/routes/oembed.ts
+++ b/src/server/routes/oembed.ts
@@ -1,0 +1,52 @@
+import typedPlugin from '@/server/typedPlugin';
+import z from 'zod';
+
+export const PATH = '/oembed';
+
+export default typedPlugin(
+  async (server) => {
+    server.get(
+      PATH,
+      {
+        schema: {
+          description: 'oEmbed endpoint to return custom embed metadata for Discord/Telegram.',
+          querystring: z.object({
+            author: z.string().nullish(),
+            author_url: z.string().nullish(),
+            provider: z.string().nullish(),
+            provider_url: z.string().nullish(),
+            title: z.string().nullish(),
+          }),
+          response: {
+            200: z.object({
+              version: z.string(),
+              type: z.string(),
+              title: z.string(),
+              author_name: z.string(),
+              author_url: z.string(),
+              provider_name: z.string(),
+              provider_url: z.string(),
+            }),
+          },
+        },
+      },
+      async (req, res) => {
+        const { author, author_url, provider, provider_url, title } = req.query;
+
+        return res
+          .type('application/json')
+          .header('Cache-Control', 'public, max-age=86400')
+          .send({
+            version: '1.0',
+            type: 'rich',
+            title: title ?? 'Zipline',
+            author_name: author ?? '',
+            author_url: author_url ?? '',
+            provider_name: provider ?? 'Zipline',
+            provider_url: provider_url ?? '',
+          });
+      },
+    );
+  },
+  { name: PATH },
+);

--- a/src/server/startup/handlers.ts
+++ b/src/server/startup/handlers.ts
@@ -1,9 +1,10 @@
 import { ApiError, RedirectError } from '@/lib/api/errors';
 import type { FastifyInstance } from 'fastify';
 import { hasZodFastifySchemaValidationErrors, isResponseSerializationError } from 'fastify-type-provider-zod';
+import { prisma } from '@/lib/db';
 
 export function registerHandlers(server: FastifyInstance, mode: string) {
-  server.setNotFoundHandler((req, res) => {
+  server.setNotFoundHandler(async (req, res) => {
     if (mode === 'development' && server.vite)
       return res.status(404).send({
         message: `Route ${req.method}:${req.url} not found`,
@@ -19,6 +20,26 @@ export function registerHandlers(server: FastifyInstance, mode: string) {
         statusCode: 404,
       });
     } else {
+      const path = req.url.split('?')[0];
+      const username = path.startsWith('/') ? path.substring(1) : path;
+      if (
+        username &&
+        !username.includes('/') &&
+        !['dashboard', 'auth', 'folder', 'view', 'raw', 'r', 'oembed'].includes(username.toLowerCase())
+      ) {
+        const user = await prisma.user.findFirst({
+          where: {
+            username: {
+              equals: username,
+              mode: 'insensitive',
+            },
+          },
+        });
+        if (user) {
+          return res.serveProfile(user.username);
+        }
+      }
+
       res.status(404);
       return res.serveIndex();
     }

--- a/src/server/startup/routes.ts
+++ b/src/server/startup/routes.ts
@@ -22,6 +22,10 @@ export async function registerRoutes(server: FastifyInstance, mode: string) {
     return res.ssr('view-url');
   });
 
+  server.get<{ Params: { username: string } }>('/user/:username', async (req, res) => {
+    return res.serveProfile(req.params.username);
+  });
+
   if (config.files.route === '/' && config.urls.route === '/') {
     logger.debug('files & urls route = /, using catch-all route');
 
@@ -53,6 +57,7 @@ export async function registerRoutes(server: FastifyInstance, mode: string) {
     server.serveIndex('/dashboard*');
     server.serveIndex('/auth*');
     server.serveIndex('/folder*');
+    server.serveIndex('/user*');
   }
 
   server.get('/', (_, res) => res.redirect('/dashboard', 301));


### PR DESCRIPTION
Implements public user profiles and related features: adds profile page, server-side profile rendering and /user/:username route, oEmbed endpoint, and avatar/banner binary endpoints. Adds public flag and image/video width/height to File model and plumbing (upload, partial assembler, APIs, DB selectors, UI). Revamps Markdown rendering using marked + highlight.js with DOMPurify hooks, improves media/link handling (disable drag, force external links), and small UI additions (profile settings, file public toggle, profile preview). Also updates global CSS and Vite plugin to serve profiles.

Includes API, server, client, DB schema and styling changes. also open link in new tab when html markdown or almost any link too.

Preview:
<img width="1919" height="921" alt="Screenshot 2026-06-06 061738" src="https://github.com/user-attachments/assets/963e9f3b-8c76-4f8a-aa8c-8c6330395445" />
<img width="1919" height="917" alt="Screenshot 2026-06-06 061752" src="https://github.com/user-attachments/assets/16c8d457-1d25-4bbd-ac84-477445740c8a" />
<img width="809" height="851" alt="Screenshot 2026-06-06 061912" src="https://github.com/user-attachments/assets/f0493e38-28a6-4bfd-a618-0320e5f182cc" />
<img width="815" height="787" alt="Screenshot 2026-06-06 061933" src="https://github.com/user-attachments/assets/447c3e08-0cb6-49a4-a790-5edfe0829be5" />
<img width="1919" height="917" alt="Screenshot 2026-06-06 062202" src="https://github.com/user-attachments/assets/1f7ba6e3-3a5b-44c3-9a23-af5493895a11" />

Profile System Preview Link:
https://ezhub.qzz.io/l7neg