### PR TITLE
fix: prevent stateful regex from rejecting valid domains (#1126)

### DIFF
--- a/src/server/routes/api/server/settings/index.ts
+++ b/src/server/routes/api/server/settings/index.ts
@@ -388,7 +388,7 @@ export default typedPlugin(
                 z
                   .string()
                   .regex(
-                    /^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,30})$/gi,
+                    /^(?:[a-zA-Z0-9_](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])?\.)+[a-zA-Z]{2,63}$/i,
                     'Invalid Domain',
                   ),
               ),


### PR DESCRIPTION
# fix: accept all valid domain shapes in settings validation

Closes #1126.

## Problem

Adding a domain under `/dashboard/admin/settings/domains` fails with `Invalid Domain`, including for domains that are obviously valid.

## Cause

The `domains` validator in `src/server/routes/api/server/settings/index.ts` used:

```js
/^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,30})$/gi
```

Structurally this is `label . ( TLD{1,6} | label . TLD{2,30} )`, which means it only accepts a domain with **exactly two or three labels**, and in the two-label case only a TLD of **at most six characters**. So these are all rejected:

- `a.b.example.com` — four labels
- `cdn.files.example.org` — four labels
- `example.software` — two labels, 8-character TLD
- `example.technology` — two labels, 10-character TLD

It also accepts `bad-.com`, since `[a-zA-Z0-9]{0,1}` makes the label's final character optional and a trailing hyphen slips through.

This is amplified by the settings form. `Domains.tsx` resubmits the whole list on every add:

```ts
await updateDomains([...domains, domain]);
```

`z.array(...)` rejects the entire request if any element fails, so a single pre-existing entry the pattern doesn't accept makes **every subsequent add fail**, regardless of what is typed.

That is exactly what happened in #1126. The instance already had `catgirls.solutions` stored — `.solutions` is 9 characters, over the 6-character ceiling, so it never matched the pattern. From that point on every add was dead on arrival:

```text
existing: ["catgirls.solutions"]

add "catgirls.host"  -> ["catgirls.solutions", "catgirls.host"]  -> REJECTED
add "example.com"    -> ["catgirls.solutions", "example.com"]    -> REJECTED
```

Both added domains are individually valid and both match the old pattern on their own. The rejection came from the untouched element already in the list, but the UI surfaces it as `Invalid Domain` against the domain being typed — which is why the error looked nonsensical for input as ordinary as `example.com`.

Worth noting how such an entry gets stored at all: this regex only guards the settings API route. The core config schema is `domains: z.array(z.string()).default([])` (`src/lib/config/validate.ts`), and the `DOMAINS` env var is read as a plain `string[]` (`src/lib/config/read/env.ts`). So a domain can enter through env or config without ever meeting the pattern, then permanently block edits through the dashboard.

## Fix

```js
/^(?:[a-zA-Z0-9_](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])?\.)+[a-zA-Z]{2,63}$/i
```

- `(?:label\.)+` accepts any number of subdomain levels rather than a hardcoded two or three.
- Each label must start and end with an alphanumeric (or underscore), so leading/trailing hyphens are rejected in every label, not just the first.
- Labels stay capped at 63 characters (1 + 61 + 1) per RFC 1035.
- TLD is `{2,63}` alphabetic — no more 6-character ceiling, and single-letter TLDs (which don't exist) are no longer accepted.
- Dropped the `g` flag. It isn't causing failures today — zod's `$ZodCheckRegex` resets `lastIndex` before each `.test()` — but `g` on a shared `RegExp` reused across `.test()` calls is a footgun with no upside here.

## Behavior change

| Domain | Before | After |
| --- | --- | --- |
| `example.com` | pass | pass |
| `catgirls.host` | pass | pass |
| `catgirls.solutions` | **fail** | pass |
| `sub.example.com` | pass | pass |
| `my-domain.co.uk` | pass | pass |
| `EXAMPLE.COM` | pass | pass |
| `xn--80ak6aa92e.com` | pass | pass |
| `a.b.example.com` | **fail** | pass |
| `cdn.files.example.org` | **fail** | pass |
| `example.software` | **fail** | pass |
| `example.technology` | **fail** | pass |
| `bad-.com` | **pass** | fail |
| `x.c` | pass | **fail** |
| `-bad.com` | fail | fail |
| `example..com` | fail | fail |
| `localhost` | fail | fail |
| `no-tld` | fail | fail |
| `127.0.0.1` | fail | fail |

Two intentional tightenings: `bad-.com` (trailing hyphen was never valid) and `x.c` (no single-letter TLDs exist).

## Testing

Verified against the case matrix above, both directly and through the actual `z.union([z.array(z.string().regex(...)), ...])` schema.

Reproduced the reported failure precisely — with `catgirls.solutions` already stored, adding either `catgirls.host` or `example.com` is rejected under the old pattern and accepted under the new one. Also confirmed end to end on a local Docker build.
