### PR TITLE
fix: URL-encode filenames using encodeURIComponent to handle spaces and special characters

### DIFF
--- a/src/client/pages/view/[id].tsx
+++ b/src/client/pages/view/[id].tsx
@@ -64,7 +64,9 @@ export default function ViewFileId() {
 
           if (res.ok) {
             const json = (await res.json()) as { token: string };
-            window.location.replace(`/view/${file.name}?token=${encodeURIComponent(json.token)}`);
+            window.location.replace(
+              `/view/${encodeURIComponent(file.name!)}?token=${encodeURIComponent(json.token)}`,
+            );
           } else {
             setPasswordError('Invalid password');
           }
@@ -105,7 +107,7 @@ export default function ViewFileId() {
               size='md'
               variant='outline'
               component={Link}
-              to={`/raw/${file.name}?download=true${token ? `&token=${encodeURIComponent(token)}` : ''}`}
+              to={`/raw/${encodeURIComponent(file.name!)}?download=true${token ? `&token=${encodeURIComponent(token)}` : ''}`}
               target='_blank'
             >
               <IconDownload size='1rem' />
@@ -127,7 +129,7 @@ export default function ViewFileId() {
                       user: user as User,
                       link: {
                         returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
-                        raw: `${host}/raw/${file.name}`,
+                        raw: `${host}/raw/${encodeURIComponent(file.name!)}`,
                       },
                       ...metrics,
                     }) ?? '',
@@ -195,7 +197,7 @@ export default function ViewFileId() {
                   size='md'
                   variant='outline'
                   component={Link}
-                  to={`/raw/${file.name}${token ? `?token=${encodeURIComponent(token)}` : ''}`}
+                  to={`/raw/${encodeURIComponent(file.name!)}${token ? `?token=${encodeURIComponent(token)}` : ''}`}
                   target='_blank'
                 >
                   <IconExternalLink size='1rem' />
@@ -206,7 +208,7 @@ export default function ViewFileId() {
                   size='md'
                   variant='outline'
                   component={Link}
-                  to={`/raw/${file.name}?download=true${token ? `&token=${encodeURIComponent(token)}` : ''}`}
+                  to={`/raw/${encodeURIComponent(file.name!)}?download=true${token ? `&token=${encodeURIComponent(token)}` : ''}`}
                   target='_blank'
                 >
                   <IconDownload size='1rem' />
@@ -228,7 +230,7 @@ export default function ViewFileId() {
                       file: file as unknown as File,
                       link: {
                         returned: `${host}${formatRootUrl(filesRoute ?? '/u', file.name!)}`,
-                        raw: `${host}/raw/${file.name}`,
+                        raw: `${host}/raw/${encodeURIComponent(file.name!)}`,
                       },
                       user: user as User,
                       ...metrics,

--- a/src/client/ssr-view/server.tsx
+++ b/src/client/ssr-view/server.tsx
@@ -218,10 +218,10 @@ export async function render(
     showMediaOg && file.type?.startsWith('image')
       ? `
     <meta property="og:type" content="image" />
-    <meta property="og:image" itemProp="image" content="${host}/raw/${safeFilename}" />
+    <meta property="og:image" itemProp="image" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
     <meta property="og:url" content="${pageUrl}" />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:image" content="${host}/raw/${safeFilename}" />
+    <meta property="twitter:image" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
     ${showRichOg ? `<meta property="twitter:title" content="${safeFilename}" />` : ''}
   `
       : '';
@@ -232,7 +232,7 @@ export async function render(
     ${file.thumbnail ? `<meta property="og:image" content="${host}/raw/${file.thumbnail.path}" />` : ''}
     <meta property="og:type" content="video.other" />
     <meta property="og:url" content="${pageUrl}" />
-    <meta property="og:video:url" content="${host}/raw/${safeFilename}" />
+    <meta property="og:video:url" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
     <meta property="og:video:width" content="1920" />
     <meta property="og:video:height" content="1080" />
   `
@@ -242,8 +242,8 @@ export async function render(
     showMediaOg && file.type?.startsWith('audio')
       ? `
     <meta name="twitter:card" content="player" />
-    <meta name="twitter:player" content="${host}/raw/${safeFilename}" />
-    <meta name="twitter:player:stream" content="${host}/raw/${safeFilename}" />
+    <meta name="twitter:player" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
+    <meta name="twitter:player:stream" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
     <meta name="twitter:player:stream:content_type" content="${safeType}" />
     ${showRichOg ? `<meta name="twitter:title" content="${safeFilename}" />` : ''}
     <meta name="twitter:player:width" content="720" />
@@ -251,8 +251,8 @@ export async function render(
 
     <meta property="og:type" content="music.song" />
     <meta property="og:url" content="${pageUrl}" />
-    <meta property="og:audio" content="${host}/raw/${safeFilename}" />
-    <meta property="og:audio:secure_url" content="${host}/raw/${safeFilename}" />
+    <meta property="og:audio" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
+    <meta property="og:audio:secure_url" content="${host}/raw/${encodeURIComponent(safeFilename)}" />
     <meta property="og:audio:type" content="${safeType}" />
   `
       : '';

--- a/src/components/file/DashboardFileType/useFileUrls.ts
+++ b/src/components/file/DashboardFileType/useFileUrls.ts
@@ -28,8 +28,11 @@ export default function useFileUrls({ file, token }: { file: DbFile | File; toke
     const thumbnailUrl = thumb ? (user ? `/api/user/files/${thumb}/raw` : `/raw/${thumb}`) : null;
 
     return {
-      fileUrl: appendToken(user ? `/api/user/files/${file.id}/raw` : `/raw/${file.name}`, token),
-      viewUrl: appendToken(`/view/${file.name}`, token),
+      fileUrl: appendToken(
+        user ? `/api/user/files/${file.id}/raw` : `/raw/${encodeURIComponent(file.name)}`,
+        token,
+      ),
+      viewUrl: appendToken(`/view/${encodeURIComponent(file.name)}`, token),
       thumbnailUrl,
     };
   }, [token, blobUrl, file, user]);

--- a/src/components/file/actions.tsx
+++ b/src/components/file/actions.tsx
@@ -20,19 +20,19 @@ import {
 import { mutate } from 'swr';
 
 export function viewFile(file: File) {
-  window.open(`/view/${file.name}`, '_blank');
+  window.open(`/view/${encodeURIComponent(file.name)}`, '_blank');
 }
 
 export function downloadFile(file: File) {
-  window.open(`/raw/${file.name}?download=true`, '_blank');
+  window.open(`/raw/${encodeURIComponent(file.name)}?download=true`, '_blank');
 }
 
 export function copyFile(file: File, clipboard: ReturnType<typeof useClipboard>, raw: boolean = false) {
   const url = raw
-    ? getDomain(`/raw/${file.name}`)
+    ? getDomain(`/raw/${encodeURIComponent(file.name)}`)
     : file.url
       ? getDomain(file.url)
-      : getDomain(`/view/${file.name}`);
+      : getDomain(`/view/${encodeURIComponent(file.name)}`);
 
   copyLink(url, clipboard);
 }

--- a/src/components/pages/files/views/FilesTableView.tsx
+++ b/src/components/pages/files/views/FilesTableView.tsx
@@ -534,7 +534,7 @@ export default function FileTable({
                   </Tooltip>
 
                   <Tooltip label='View file in new tab'>
-                    <Link to={`/view/${file.name}`} target='_blank'>
+                    <Link to={`/view/${encodeURIComponent(file.name)}`} target='_blank'>
                       <ActionIcon color='blue'>
                         <IconExternalLink size='1rem' />
                       </ActionIcon>

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,5 +1,5 @@
 export function formatRootUrl(route: string, src: string) {
-  return `${route === '/' ? '' : route}/${encodeURI(src)}`;
+  return `${route === '/' ? '' : route}/${encodeURIComponent(src)}`;
 }
 
 export function trimUrl(length: number, url: string) {

--- a/src/offload/partial.ts
+++ b/src/offload/partial.ts
@@ -196,7 +196,7 @@ async function runComplete(id: string, size: number) {
     user: userr,
     file: { ...fileUpload, thumbnail: null, tags: [] },
     link: {
-      raw: `${domain}/raw/${fileUpload.name}`,
+      raw: `${domain}/raw/${encodeURIComponent(fileUpload.name)}`,
       returned: responseUrl,
     },
   });

--- a/src/server/routes/api/upload/index.ts
+++ b/src/server/routes/api/upload/index.ts
@@ -326,7 +326,7 @@ export default typedPlugin(
               ? fileUpload.name.slice(0, -extension.length)
               : fileUpload.name;
 
-          const responseUrl = `${domain}${config.files.route === '/' || config.files.route === '' ? '' : `${config.files.route}`}/${urlPath}`;
+          const responseUrl = `${domain}${config.files.route === '/' || config.files.route === '' ? '' : `${config.files.route}`}/${encodeURIComponent(urlPath)}`;
 
           const compressedResponse = compressed
             ? { mimetype: compressed.mimetype, ext: compressed.ext, failed: compressed.failed }
@@ -336,7 +336,7 @@ export default typedPlugin(
             id: fileUpload.id,
             name: fileUpload.name,
             type: fileUpload.type,
-            url: encodeURI(responseUrl),
+            url: responseUrl,
             removedGps: removedGps || undefined,
             compressed: compressedResponse,
           };
@@ -357,7 +357,7 @@ export default typedPlugin(
             file: { ...fileUpload, thumbnail: null, tags: [] },
             link: {
               raw: `${domain}/raw/${encodeURIComponent(fileUpload.name)}`,
-              returned: encodeURI(responseUrl),
+              returned: responseUrl,
             },
           });
 

--- a/src/server/routes/api/upload/partial.ts
+++ b/src/server/routes/api/upload/partial.ts
@@ -360,7 +360,7 @@ export default typedPlugin(
 
           const responseUrl = `${domain}${
             config.files.route === '/' || config.files.route === '' ? '' : `${config.files.route}`
-          }/${urlPath}`;
+          }/${encodeURIComponent(urlPath)}`;
 
           const worker = createWorker('offload/partial.js', {
             workerData: {


### PR DESCRIPTION
### Problem
When files are uploaded with `"Add Original Name"` enabled or with `format: name`, original filenames containing spaces and special characters (e.g. `Die Einladung.zip`, `report#1.pdf`, `C++ guide.txt`, `100%_sale.pdf`) produced broken URLs across several areas:
- **Spaces (` `):** Truncated by chat apps (Discord, Slack, WhatsApp) and markdown parsers at the first space, leading to 404s.
- **Hashtags (`#`):** Interpreted by browsers as fragment anchors and stripped from the request path.
- **Question marks (`?`):** Interpreted by browsers as the start of query parameters.
- **Ampersands (`&`), Plus signs (`+`), Percents (`%`):** Caused routing/query parsing issues or invalid URI sequence errors.
While `/api/upload` used `encodeURI()`, it left `#`, `?`, `&`, `+` unencoded. Meanwhile, `/api/upload/partial` and frontend link generation omitted encoding entirely.
### Solution
Replaced all filename-in-URL path interpolations with `encodeURIComponent()`:
- `src/lib/url.ts`: Updated `formatRootUrl()` to use `encodeURIComponent()`.
- `src/server/routes/api/upload/index.ts` & `partial.ts`: URL-encoded `responseUrl` path components in standard and chunked upload responses.
- `src/offload/partial.ts`: URL-encoded raw links in webhook completion payloads.
- `src/client/ssr-view/server.tsx`: URL-encoded media filenames in OpenGraph and Twitter embed meta tags (`og:image`, `og:video:url`, `og:audio`, `twitter:player`).
- `src/components/file/actions.tsx`, `useFileUrls.ts`, `FilesTableView.tsx`, `view/[id].tsx`: URL-encoded filenames for dashboard actions (view/download/copy link), table links, and view page buttons.
