### PR TITLE
feat: add iTake generator (macOS only)

### DIFF
--- a/src/components/pages/settings/parts/SettingsGenerators/GeneratorButton.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/GeneratorButton.tsx
@@ -19,6 +19,7 @@ import { flameshot } from './generators/flameshot';
 import { sharex } from './generators/sharex';
 import { shell } from './generators/shell';
 import { ishare } from './generators/ishare';
+import { itake } from './generators/itake';
 import { Link } from 'react-router-dom';
 
 export type GeneratorOptions = {
@@ -86,6 +87,7 @@ const generators = {
   ShareX: sharex,
   'Shell Script': shell,
   ishare,
+  iTake: itake,
 };
 
 export default function GeneratorButton({
@@ -133,7 +135,7 @@ export default function GeneratorButton({
           <Select
             data={[
               { label: 'Upload File', value: 'file' },
-              { label: 'Shorten URL', value: 'url', disabled: name === 'ishare' },
+              { label: 'Shorten URL', value: 'url', disabled: name === 'ishare' || name === 'iTake' },
             ]}
             description='Select which type of destination you want to generate'
             label='Destination Type'

--- a/src/components/pages/settings/parts/SettingsGenerators/generators/itake.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/generators/itake.tsx
@@ -1,0 +1,78 @@
+import { UploadHeaders } from '@/lib/uploader/parseHeaders';
+import { GeneratorOptions, download } from '../GeneratorButton';
+
+export function itake(token: string, type: 'file' | 'url', options: GeneratorOptions) {
+  if (type === 'url') {
+    // unsupported in itake
+    return;
+  }
+
+  const config = {
+    name: `Zipline - ${window.location.origin} - File`,
+    request: {
+      url: `${window.location.origin}/api/upload`,
+      method: 'POST',
+      headers: {},
+    },
+    body: {
+      type: 'multipart',
+      fileField: 'file',
+      fields: {},
+    },
+    response: {
+      linkPath: 'files.0.url',
+    },
+  };
+
+  const toAddHeaders: UploadHeaders = {
+    authorization: token,
+  };
+
+  if (options.deletesAt !== null && type === 'file') {
+    toAddHeaders['x-zipline-deletes-at'] = options.deletesAt;
+  } else {
+    delete toAddHeaders['x-zipline-deletes-at'];
+  }
+
+  if (options.format !== 'default' && type === 'file') {
+    toAddHeaders['x-zipline-format'] = options.format;
+  } else {
+    delete toAddHeaders['x-zipline-format'];
+  }
+
+  if (options.imageCompressionPercent !== null && type === 'file') {
+    toAddHeaders['x-zipline-image-compression-percent'] = options.imageCompressionPercent.toString();
+  } else {
+    delete toAddHeaders['x-zipline-image-compression-percent'];
+  }
+
+  if (options.maxViews !== null) {
+    toAddHeaders['x-zipline-max-views'] = options.maxViews.toString();
+  } else {
+    delete toAddHeaders['x-zipline-max-views'];
+  }
+
+  if (options.addOriginalName === true && type === 'file') {
+    toAddHeaders['x-zipline-original-name'] = 'true';
+  } else {
+    delete toAddHeaders['x-zipline-original-name'];
+  }
+
+  if (options.extensionless === true && type === 'file') {
+    toAddHeaders['x-zipline-extensionless'] = 'true';
+  } else {
+    delete toAddHeaders['x-zipline-extensionless'];
+  }
+
+  if (options.overrides_returnDomain !== null) {
+    toAddHeaders['x-zipline-domain'] = options.overrides_returnDomain;
+  } else {
+    delete toAddHeaders['x-zipline-domain'];
+  }
+
+  for (const [key, value] of Object.entries(toAddHeaders)) {
+    (config.request.headers as any)[key] = value;
+  }
+
+  return download(`zipline-${type}.itup`, JSON.stringify(config, null, 2));
+}

--- a/src/components/pages/settings/parts/SettingsGenerators/index.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/index.tsx
@@ -64,6 +64,23 @@ export default function SettingsGenerators() {
           }
         />
         <GeneratorButton
+          name='iTake'
+          icon={
+            <MantineImage
+              width={24}
+              height={24}
+              alt='iTake logo'
+              src='https://raw.githubusercontent.com/SerStars/iTake/refs/heads/main/preview/AppIcon.png'
+            />
+          }
+          desc={
+            <>
+              This generator requires <Anchor href='https://github.com/SerStars/iTake'>iTake</Anchor> to be
+              installed on macOS. This uploader is intended for use on macOS only.
+            </>
+          }
+        />
+        <GeneratorButton
           name='Shell Script'
           icon={<IconPrompt size={24} />}
           desc={


### PR DESCRIPTION
Added iTake to the uploader generator
iTake is a new screenshot tool for MacOS, which improves and adds upon older applications
Can be found at https://github.com/SerStars/iTake